### PR TITLE
Ensure space between syslog message timestamp and host

### DIFF
--- a/jobs/rabbitmq-server/templates/syslog_forwarder.conf.erb
+++ b/jobs/rabbitmq-server/templates/syslog_forwarder.conf.erb
@@ -34,7 +34,7 @@ template(name="CfLogTemplate" type="list") {
         property(name="pri")
         constant(value=">")
         property(name="timestamp" dateFormat="rfc3339")
-        constant(value="<%= job_ip %> ")
+        constant(value=" <%= job_ip %> ")
         property(name="programname")
         constant(value=" [job=<%= name %> index=<%= spec.index.to_i %>] ")
         property(name="msg")


### PR DESCRIPTION
This PR fixes a small bug in the syslog message format emitted by the `rabbitmq-server` job.

Specifically, the syslog messages currently emitted have no space between the timestamp and the hostname field, eg:

```
<86>2015-07-22T06:25:01.125590+00:0010.0.16.69 CRON [job=rabbitmq-server-partition-29e21cc7d06806e34ac3 index=1]  pam_unix(cron:session): session closed for user root
```
Note the lack of space between `015-07-22T06:25:01.125590+00:00` and `10.0.16.69`

This PR updates the `syslog_forwarder.conf.erb` config to match that of the [`cf-redis-release`](https://github.com/pivotal-cf/cf-redis-release/blob/master/jobs/syslog-configurator/templates/syslog_forwarder.conf.erb#L30) so that there is a space.  This makes parsing of the syslog message easier (and consistent with parsing of other bosh jobs' syslog messages)

