### PR TITLE
Add support for verify and fail_if_no_peer_cert ssl_options 

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -18,6 +18,10 @@ properties:
   rabbitmq-server.ssl.security_options:
     description: "SSL security options (currently only 'enable_tls1_0')"
     default: []
+  rabbitmq-server.ssl.verify:
+    description: "Verify peer method used by RabbitMQ server"
+  rabbitmq-server.ssl.fail_if_no_peer_cert:
+    description: "Should RabbitMQ server fail if there is no peer cert"
 
   rabbitmq-server.plugins:
     description: "RabbitMQ plugins (array of strings)"

--- a/jobs/rabbitmq-server/templates/setup.sh.erb
+++ b/jobs/rabbitmq-server/templates/setup.sh.erb
@@ -33,6 +33,14 @@ security_options = p('rabbitmq-server.ssl.security_options')
 if security_options.include?('enable_tls1_0')
   supported_tls_versions << "tlsv1"
 end
+verify_peer = 'verify_none'
+if_p("rabbitmq-server.ssl.verify") do |v|
+  verify_peer = v
+end
+fail_if_no_peer_cert = false
+if_p("rabbitmq-server.ssl.fail_if_no_peer_cert") do |f|
+  fail_if_no_peer_cert = f
+end
 
 %>
 (
@@ -137,7 +145,7 @@ end
   <% if ssl %>
   # concatenate options encoded in double quotes, see the concatenation comment above.
   # {versions,['tlsv1.2','tlsv1.1',tlsv1]} disables SSLv3 to mitigate the POODLE attack.
-  SSL_OPTIONS=" -rabbit ssl_options [{cacertfile,\\\"${SCRIPT_DIR}/../etc/cacert.pem\\\"},{certfile,\\\"${SCRIPT_DIR}/../etc/cert.pem\\\"},{keyfile,\\\"${SCRIPT_DIR}/../etc/key.pem\\\"},{verify,verify_none},{fail_if_no_peer_cert,false},{versions,<%= "[#{supported_tls_versions.join(',')}]" %>}]"
+  SSL_OPTIONS=" -rabbit ssl_options [{cacertfile,\\\"${SCRIPT_DIR}/../etc/cacert.pem\\\"},{certfile,\\\"${SCRIPT_DIR}/../etc/cert.pem\\\"},{keyfile,\\\"${SCRIPT_DIR}/../etc/key.pem\\\"},{verify,<%= "#{verify_peer}" %>},{fail_if_no_peer_cert,<%= "#{fail_if_no_peer_cert}" %>},{versions,<%= "[#{supported_tls_versions.join(',')}]" %>}]"
   SERVER_START_ARGS="${SERVER_START_ARGS}\"${SSL_OPTIONS}\""
   <% end %>
   if [ -f ${CONF_ENV_FILE} ]


### PR DESCRIPTION
Existing bosh manifest doesn't allow configuration of `verify` and `fail_if_no_peer_cert` ssl_options. These properties are always defaulted to `verify_none` and `false` respectively. This causes problem when one wants to deploy rabbitmq with two way TLS enabled.

This PR adds these two properties that can be configured in bosh deployment manifest to enable two way TLS. If not specified in bosh deployment manifest then it defaults to `verify_none` and `false`.

This addresses the issue https://github.com/pivotal-cf/cf-rabbitmq-release/issues/21 that we raised yesterday.

Regards,
@atulkc and @ruchirtewari