### PR TITLE
Add the support of an OpenStack IaaS environment

### DIFF
--- a/scripts/generate-manifest
+++ b/scripts/generate-manifest
@@ -12,8 +12,9 @@ infrastructure="${1:?}"
 
 shift
 
-if [ "$infrastructure" != "aws" ]; then
-  echo "usage: ./scripts/generate-manifest aws [stubs...]" 1>&2
+if [ "$infrastructure" != "openstack" ] && \
+    [ "$infrastructure" != "aws" ]; then
+  echo "usage: ./scripts/generate-manifest <aws|openstack> [stubs...]" 1>&2
   exit 1
 fi
 

--- a/templates/cf-rabbitmq-infrastructure-openstack.yml
+++ b/templates/cf-rabbitmq-infrastructure-openstack.yml
@@ -1,0 +1,27 @@
+meta:
+  stemcell:
+    name: bosh-openstack-kvm-ubuntu-trusty-go_agent
+    version: 3215
+
+networks: (( merge ))
+
+resource_pools:
+- name: services-small-z1
+  cloud_properties:
+    instance_type: (( merge || "m3.medium" ))
+  network: rabbitmq_z1
+  stemcell: (( meta.stemcell ))
+
+- name: services-small-z2
+  cloud_properties:
+    instance_type: (( merge || "m3.medium" ))
+  network: rabbitmq_z2
+  stemcell: (( meta.stemcell ))
+
+
+compilation:
+  cloud_properties:
+    instance_type: (( merge || "c3.xlarge" ))
+  network: rabbitmq_z1
+  reuse_compilation_vms: true
+  workers: 6


### PR DESCRIPTION
Currently the templates and the manifest generation script only take over an AWS environment. We had to deploy cf-rabbitmq on an OpenStack IaaS and for this we added the support of this new environment in the corresponding files. In view of the popularity of OpenStack, we are making this pull request because we think it could be useful for the community too.