### PR TITLE
Add the ability to register to multiple NAT servers

### DIFF
--- a/jobs/rabbitmq-broker/spec
+++ b/jobs/rabbitmq-broker/spec
@@ -97,6 +97,9 @@ properties:
     description: "The user to use when authenticating with NATS"
   cf.nats.password:
     description: "The password to use when authenticating with NATS"
+  cf.nats_servers:
+    description: "An array of NATS server host, port, username and password"
+    default: []
 
   syslog_aggregator.address:
     description: "Syslog drain hostname"

--- a/jobs/rabbitmq-broker/templates/broker_registrar_settings.yml.erb
+++ b/jobs/rabbitmq-broker/templates/broker_registrar_settings.yml.erb
@@ -1,8 +1,16 @@
 ---
 message_bus_servers:
+<% if !properties.cf.nats_servers.empty? %>
+  <% p('cf.nats_servers').each do |server| %>
+  - host: <%= server["host"] %>:<%= server["port"] %>
+    user: <%= server["username"] %>
+    password: <%= server["password"] %>
+  <% end %>
+<% else %>
   - host: <%= p('cf.nats.host') %>:<%= p('cf.nats.port') %>
     user: <%= p('cf.nats.username') %>
     password: <%= p('cf.nats.password') %>
+<% end %>
 host: <%= p('rabbitmq-broker.ip')%>
 routes:
   - name: <%= p('rabbitmq-broker.route') %>

--- a/jobs/rabbitmq-broker/templates/management_registrar_settings.yml.erb
+++ b/jobs/rabbitmq-broker/templates/management_registrar_settings.yml.erb
@@ -1,8 +1,16 @@
 ---
 message_bus_servers:
+<% if !properties.cf.nats_servers.empty? %>
+  <% p('cf.nats_servers').each do |server| %>
+  - host: <%= server["host"] %>:<%= server["port"] %>
+    user: <%= server["username"] %>
+    password: <%= server["password"] %>
+  <% end %>
+<% else %>
   - host: <%= p('cf.nats.host') %>:<%= p('cf.nats.port') %>
     user: <%= p('cf.nats.username') %>
     password: <%= p('cf.nats.password') %>
+<% end %>
 host: <%= p('rabbitmq-broker.rabbitmq.management_ip') %>
 routes:
   - name: <%= p('rabbitmq-broker.rabbitmq.management_domain') %>


### PR DESCRIPTION
This is backwards compatible with the existing bosh manifest nats configuration.

We need this to make this service highly available in the event a NATs server goes down.