### PR TITLE
Optimise prepare_for_upgrade

### DIFF
--- a/jobs/rabbitmq-server/templates/prepare-for-upgrade.bash
+++ b/jobs/rabbitmq-server/templates/prepare-for-upgrade.bash
@@ -15,7 +15,7 @@ STDERR_LOG="${LOG_DIR}"/pre-start.stderr.log
 main() {
   run_script "${JOB_DIR}/bin/setup.sh"
   run_script "${JOB_DIR}/bin/plugins.sh"
-  prepare_for_upgrade
+  is_first_deploy || prepare_for_upgrade
 }
 
 run_script() {
@@ -41,11 +41,22 @@ run_script() {
     esac
 }
 
+is_first_deploy() {
+  ! [ -e /var/vcap/store/rabbitmq/mnesia ]
+}
+
 prepare_for_upgrade () {
   echo "Preparing RabbitMQ for potential upgrade"
-  local remote_nodes
+  local remote_nodes local_node
   remote_nodes=($(cat /var/vcap/data/upgrade_preparation_nodes))
+  # shellcheck disable=SC1091
+  local_node=$(. /var/vcap/store/rabbitmq/etc/rabbitmq/rabbitmq-env.conf; echo "$NODENAME")
+
   for remote_node in "${remote_nodes[@]}"; do
+    # since the current node is already down,
+    # the rabbitmq-upgrade-preparation will timeout
+    # skip over the current node
+    [ "$remote_node" != "$local_node" ] || continue
     /var/vcap/packages/rabbitmq-upgrade-preparation/bin/rabbitmq-upgrade-preparation \
       -rabbitmqctl-path "${CONTROL}" \
       -node "$remote_node" \


### PR DESCRIPTION
This should never be invoked on a running node. If it is, it means that
the shutdown wasn't performed properly (i.e. bosh stop).

Skip upgrade check if it's a first deploy since there is nothing to upgrade

Signed-off-by: Jean-Sébastien Pedron <jean-sebastien@rabbitmq.com>