### PR TITLE
Increase incoming max connection count

### DIFF
--- a/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
+++ b/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
@@ -18,6 +18,7 @@ global
 defaults
 	option  tcplog
         log     global
+        maxconn 64000
         timeout connect 10s
         timeout client  2d
         timeout server  2d


### PR DESCRIPTION
The maxconn parameter must be set in both the global and the defaults section. The one in the defaults section sets the max number of incoming connections to haproxy, and without this, haproxy is limited to 2000 connections no matter what value is set in the global one.