### PR TITLE
Add example vars-files for 3.6 & 3.7

### DIFF
--- a/manifests/cf-rabbitmq-36.vars-file.example.yml
+++ b/manifests/cf-rabbitmq-36.vars-file.example.yml
@@ -1,0 +1,11 @@
+deployment-name: cf-rabbitmq-36
+stemcell-version: latest
+rabbitmq_version: 3.6
+rabbitmq-management-username: admin
+rabbitmq-management-password: admin
+rabbitmq-broker-username: broker
+rabbitmq-broker-password: broker
+cluster-partition-handling-strategy: pause_minority
+haproxy-instances: 1
+rabbitmq-management-hostname: cf-rabbitmq-36
+bosh-domain: rabbitmq.pivotal.io

--- a/manifests/cf-rabbitmq-37.vars-file.example.yml
+++ b/manifests/cf-rabbitmq-37.vars-file.example.yml
@@ -1,0 +1,11 @@
+deployment-name: cf-rabbitmq-37
+stemcell-version: latest
+rabbitmq_version: 3.7
+rabbitmq-management-username: admin
+rabbitmq-management-password: admin
+rabbitmq-broker-username: broker
+rabbitmq-broker-password: broker
+cluster-partition-handling-strategy: pause_minority
+haproxy-instances: 1
+rabbitmq-management-hostname: cf-rabbitmq-37
+bosh-domain: rabbitmq.pivotal.io


### PR DESCRIPTION
This makes it easy to deploy a RabbitMQ 3.6 or 3.7 using this BOSH release.