### PR TITLE
Fix the upgrade to RabbitMQ 3.7

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/github.com/pivotal-cf/rabbitmq-upgrade-preparation"]
 	path = src/github.com/pivotal-cf/rabbitmq-upgrade-preparation
-	url = git@github.com:pivotal-cf/rabbitmq-upgrade-preparation
+	url = https://github.com/pivotal-cf/rabbitmq-upgrade-preparation.git

--- a/jobs/rabbitmq-server/templates/pre-start.bash
+++ b/jobs/rabbitmq-server/templates/pre-start.bash
@@ -58,7 +58,8 @@ ensure_http_log_cleanup_cron_job() {
 }
 
 configure_rmq_version() {
-  ln -f -s /var/vcap/packages/rabbitmq-server-"$RMQ_SERVER_VERSION" /var/vcap/packages/rabbitmq-server
+  rm -rf /var/vcap/packages/rabbitmq-server
+  ln -s /var/vcap/packages/rabbitmq-server-"$RMQ_SERVER_VERSION" /var/vcap/packages/rabbitmq-server
 }
 
 setup_erl_inetrc() {


### PR DESCRIPTION
Hi,

In this PR, I implement a fix for the base issue described in #72.
Sadly, the cluster upgrade fails at some point even with this. The `rabbitmq-server` job doesn't start on the canary node in my 2-nodes cluster. I provide you with this anyway, hoping it can help.

I also added a small fix for the submodule URI, because the Git repository is public.

Cheers,
/Benjamin