### PR TITLE
Add ability to define server and client timeout for a specific port. …

### DIFF
--- a/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
+++ b/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
@@ -7,6 +7,7 @@
 
     timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).to_a
 %>
+<%=timeouts %>
 global
 	daemon
 	user vcap
@@ -29,11 +30,10 @@ defaults
 frontend input-<%= port %>
 	bind :<%= port %>
         default_backend output-<%= port %>
-        
-<%  timeouts.each do |timeout| %>
-        <%  if timeout['port'].to_i == port %>
-        timeout client <%= timeout['timeout'] %>
-        timeout server <%= timeout['timeout'] %>
+<%  timeouts.each do |index,timeout| %>
+        <%  if index.to_i == port %>
+        timeout client <%= timeout %>
+        timeout server <%= timeout %>
         <%  end %>
 <%  end %>	
 

--- a/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
+++ b/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
@@ -7,7 +7,6 @@
 
     timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).to_a
 %>
-<%=timeouts %>
 global
 	daemon
 	user vcap

--- a/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
+++ b/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
@@ -1,11 +1,11 @@
 <%
   ips = link('rabbitmq-server').instances.map(&:address)
   ports = link('rabbitmq-server').p('rabbitmq-server.ports').to_s.
-			split(/[\[\], ]/).
-			map { |port| port.to_i }.
-			select { |port| port > 0 && port < 65536 }
+      split(/[\[\], ]/).
+      map { |port| port.to_i }.
+      select { |port| port > 0 && port < 65536 }
 
-	timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).map{ | timeout| timeout.to_a}
+  timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).map{ | timeout| timeout.to_a}
 %>
 global
 daemon
@@ -26,20 +26,20 @@ timeout client  2d
 timeout server  2d
 
 <% ports.each do |port| %>
-	frontend input-<%= port %>
-	bind :<%= port %>
-	default_backend output-<%= port %>
-	<%  timeouts.each do |key, timeout| %>
-		<%  if timeout['port'] == port %>
-			timeout client <%= timeout['client'] %>
-			timeout server <%= timeout['server'] %>
-		<%  end %>
-	<%  end %>
+  frontend input-<%= port %>
+  bind :<%= port %>
+  default_backend output-<%= port %>
+  <%  timeouts.each do |key, timeout| %>
+    <%  if timeout['port'] == port %>
+      timeout client <%= timeout['client'] %>
+      timeout server <%= timeout['server'] %>
+    <%  end %>
+  <%  end %>
 
-	backend output-<%= port %>
-	mode tcp
-	balance leastconn
-	<% ips.each_with_index do |ip, idx| %>
-		server node<%= idx %> <%= ip %>:<%= port %> check inter 5000
-	<% end %>
+  backend output-<%= port %>
+  mode tcp
+  balance leastconn
+  <% ips.each_with_index do |ip, idx| %>
+    server node<%= idx %> <%= ip %>:<%= port %> check inter 5000
+  <% end %>
 <% end %>

--- a/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
+++ b/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
@@ -1,45 +1,47 @@
 <%
   ips = link('rabbitmq-server').instances.map(&:address)
   ports = link('rabbitmq-server').p('rabbitmq-server.ports').to_s.
-      split(/[\[\], ]/).
-      map { |port| port.to_i }.
-      select { |port| port > 0 && port < 65536 }
+    split(/[\[\], ]/).
+    map { |port| port.to_i }.
+    select { |port| port > 0 && port < 65536 }
 
-  timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).to_a
+    timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).to_a
 %>
 global
-daemon
-user vcap
-group vcap
-maxconn 64000
-spread-checks 4
-log 127.0.0.1 local2 info
-stats socket /var/vcap/sys/run/rabbitmq-haproxy/haproxy.sock mode 600 level admin user vcap
-stats timeout 2m #Wait up to 2 minutes for input
+	daemon
+	user vcap
+	group vcap
+	maxconn 64000
+        spread-checks 4
+        log 127.0.0.1 local2 info
+  stats socket /var/vcap/sys/run/rabbitmq-haproxy/haproxy.sock mode 600 level admin user vcap
+  stats timeout 2m #Wait up to 2 minutes for input
 
 defaults
-option  tcplog
-log     global
-maxconn 64000
-timeout connect 10s
-timeout client  2d
-timeout server  2d
+	option  tcplog
+        log     global
+        maxconn 64000
+        timeout connect 10s
+        timeout client  2d
+        timeout server  2d
 
 <% ports.each do |port| %>
-  frontend input-<%= port %>
-  bind :<%= port %>
-  default_backend output-<%= port %>
-  <%  timeouts.each do |timeout| %>
-    <%  if timeout['port'].to_i == port %>
-      timeout client <%= timeout['client'] %>
-      timeout server <%= timeout['server'] %>
-    <%  end %>
-  <%  end %>
+frontend input-<%= port %>
+	bind :<%= port %>
+        default_backend output-<%= port %>
+        
+<%  timeouts.each do |timeout| %>
+        <%  if timeout['port'].to_i == port %>
+        timeout client <%= timeout['timeout'] %>
+        timeout server <%= timeout['timeout'] %>
+        <%  end %>
+<%  end %>	
 
-  backend output-<%= port %>
-  mode tcp
-  balance leastconn
-  <% ips.each_with_index do |ip, idx| %>
-    server node<%= idx %> <%= ip %>:<%= port %> check inter 5000
-  <% end %>
+backend output-<%= port %>
+        mode tcp
+        balance leastconn
+<% ips.each_with_index do |ip, idx| %>
+	server node<%= idx %> <%= ip %>:<%= port %> check inter 5000
 <% end %>
+<% end %>
+

--- a/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
+++ b/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
@@ -5,7 +5,7 @@
       map { |port| port.to_i }.
       select { |port| port > 0 && port < 65536 }
 
-  timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).map{ | timeout| timeout.to_a}
+  timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).to_a
 %>
 global
 daemon
@@ -29,8 +29,8 @@ timeout server  2d
   frontend input-<%= port %>
   bind :<%= port %>
   default_backend output-<%= port %>
-  <%  timeouts.each do |key, timeout| %>
-    <%  if timeout['port'] == port %>
+  <%  timeouts.each do |timeout| %>
+    <%  if timeout['port'].to_i == port %>
       timeout client <%= timeout['client'] %>
       timeout server <%= timeout['server'] %>
     <%  end %>

--- a/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
+++ b/jobs/rabbitmq-haproxy/templates/haproxy.config.erb
@@ -1,38 +1,45 @@
 <%
   ips = link('rabbitmq-server').instances.map(&:address)
   ports = link('rabbitmq-server').p('rabbitmq-server.ports').to_s.
-    split(/[\[\], ]/).
-    map { |port| port.to_i }.
-    select { |port| port > 0 && port < 65536 }
+			split(/[\[\], ]/).
+			map { |port| port.to_i }.
+			select { |port| port > 0 && port < 65536 }
+
+	timeouts = link('rabbitmq-server').p('rabbitmq-server.timeouts', []).map{ | timeout| timeout.to_a}
 %>
 global
-	daemon
-	user vcap
-	group vcap
-	maxconn 64000
-        spread-checks 4
-        log 127.0.0.1 local2 info
-  stats socket /var/vcap/sys/run/rabbitmq-haproxy/haproxy.sock mode 600 level admin user vcap
-  stats timeout 2m #Wait up to 2 minutes for input
+daemon
+user vcap
+group vcap
+maxconn 64000
+spread-checks 4
+log 127.0.0.1 local2 info
+stats socket /var/vcap/sys/run/rabbitmq-haproxy/haproxy.sock mode 600 level admin user vcap
+stats timeout 2m #Wait up to 2 minutes for input
 
 defaults
-	option  tcplog
-        log     global
-        maxconn 64000
-        timeout connect 10s
-        timeout client  2d
-        timeout server  2d
+option  tcplog
+log     global
+maxconn 64000
+timeout connect 10s
+timeout client  2d
+timeout server  2d
 
 <% ports.each do |port| %>
-frontend input-<%= port %>
+	frontend input-<%= port %>
 	bind :<%= port %>
 	default_backend output-<%= port %>
+	<%  timeouts.each do |key, timeout| %>
+		<%  if timeout['port'] == port %>
+			timeout client <%= timeout['client'] %>
+			timeout server <%= timeout['server'] %>
+		<%  end %>
+	<%  end %>
 
-backend output-<%= port %>
-        mode tcp
-        balance leastconn
-<% ips.each_with_index do |ip, idx| %>
-	server node<%= idx %> <%= ip %>:<%= port %> check inter 5000
+	backend output-<%= port %>
+	mode tcp
+	balance leastconn
+	<% ips.each_with_index do |ip, idx| %>
+		server node<%= idx %> <%= ip %>:<%= port %> check inter 5000
+	<% end %>
 <% end %>
-<% end %>
-

--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -42,9 +42,7 @@ properties:
   rabbitmq-server.ports:
     description: "List of ports on which the RabbitMQ cluster accepts connections"
   rabbitmq-server.timeouts.port:
-    description: "Port for server and client timeout definitions"
-  rabbitmq-server.timeouts.port.timeout:
-    description: "Timeout in seconds for server and client"
+    description: "Server and client timeout for a specific port"
 
   rabbitmq-server.administrators.broker.username:
     description: "RabbitMQ admin username for broker"

--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -12,6 +12,10 @@ properties:
   rabbitmq-server.version:
     description: "Version of RabbitMQ to use"
     default: "3.6"
+
+  rabbitmq-server.ssl.enabled:
+    default: false
+    description: "Use TLS listeners. Will not accept non-TLS connections."
   rabbitmq-server.ssl.cacert:
     description: "RabbitMQ server CA certificate"
   rabbitmq-server.ssl.cert:
@@ -37,6 +41,10 @@ properties:
     description: "List of RabbitMQ plugins"
   rabbitmq-server.ports:
     description: "List of ports on which the RabbitMQ cluster accepts connections"
+  rabbitmq-server.timeouts.port:
+    description: "Port for server and client timeout definitions"
+  rabbitmq-server.timeouts.port.timeout:
+    description: "Timeout in seconds for server and client"
 
   rabbitmq-server.administrators.broker.username:
     description: "RabbitMQ admin username for broker"

--- a/spec/unit/templates/ha_proxy_config_spec.rb
+++ b/spec/unit/templates/ha_proxy_config_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe 'Cluster', template: true do
         ],
         'properties' => {
           'rabbitmq-server' => {
-            'ports' => [ 123, 456, 789, 10000000 ]
+            'ports' => [ 123, 456, 789, 10000000 ],
+            'timeouts' => [
+              { "port" => 123, "client" => "300s", "server" => "300s"}
+            ]
           }
         }
       }
@@ -30,5 +33,10 @@ RSpec.describe 'Cluster', template: true do
   it 'does not include too big ports' do
     expect(rendered_template).not_to include("server node0 1.1.1.1:10000000 check inter 5000")
     expect(rendered_template).not_to include("server node1 2.2.2.2:10000000 check inter 5000")
+  end
+
+  it 'should contain timeout for first port' do
+    expect(rendered_template).to include("timeout client 300s")
+    expect(rendered_template).to include("timeout server 300s")
   end
 end

--- a/spec/unit/templates/ha_proxy_config_spec.rb
+++ b/spec/unit/templates/ha_proxy_config_spec.rb
@@ -12,9 +12,7 @@ RSpec.describe 'Cluster', template: true do
         'properties' => {
           'rabbitmq-server' => {
             'ports' => [ 123, 456, 789, 10000000 ],
-            'timeouts' => [
-              { "port" => 123, "client" => "300s", "server" => "300s"}
-            ]
+            'timeouts' => [[123, "30s"]]
           }
         }
       }
@@ -36,7 +34,7 @@ RSpec.describe 'Cluster', template: true do
   end
 
   it 'should contain timeout for first port' do
-    expect(rendered_template).to include("timeout client 300s")
-    expect(rendered_template).to include("timeout server 300s")
+    expect(rendered_template).to include("timeout client 30s")
+    expect(rendered_template).to include("timeout server 30s")
   end
 end


### PR DESCRIPTION
Currently all the ports have the same timeout for `timeout client` and `timeout server` on the HAProxy. On our cluster it's not beneficial that to have the connection open for that long. Hence the changes on the HAProxy config. 

Config for timeout can be done through the manifest.yml. For example:

instance_groups:
- name: rmq
  jobs:
  - name: rabbitmq-server
    release: cf-rabbitmq
    properties:
      rabbitmq-server:
        version: 3.6
        plugins:
        - ...
        ports:
        - ...
        timeouts:
          management:
            port: 15672
            server: 20s
            client: 30s