### PR TITLE
Add the option to specify an additional plugin directory

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -49,6 +49,8 @@ properties:
 
   rabbitmq-server.plugins:
     description: "List of RabbitMQ plugins"
+  rabbitmq-server.additional_plugin_dir:
+    description: "Additional directory to look in for RabbitMQ plugins"
   rabbitmq-server.ports:
     description: "List of ports on which the RabbitMQ cluster accepts connections"
   rabbitmq-server.timeouts.port:

--- a/jobs/rabbitmq-server/templates/plugins.sh.erb
+++ b/jobs/rabbitmq-server/templates/plugins.sh.erb
@@ -7,6 +7,9 @@ write_log() {
 }
 
 (
+  <% if_p("rabbitmq-server.additional_plugin_dir") do |dir| %>
+  export RABBITMQ_PLUGINS_DIR=/var/vcap/packages/rabbitmq-server/plugins/:<%= dir %>
+  <% end %>
   if [ -z $RABBITMQ_PLUGINS ]; then
     RABBITMQ_PLUGINS=/var/vcap/packages/rabbitmq-server/bin/rabbitmq-plugins
   fi

--- a/jobs/rabbitmq-server/templates/rabbitmq-server.init.bash
+++ b/jobs/rabbitmq-server/templates/rabbitmq-server.init.bash
@@ -28,6 +28,10 @@ LOG_DIR=/var/vcap/sys/log/rabbitmq-server
 STARTUP_LOG="${LOG_DIR}"/startup_stdout.log
 STARTUP_ERR_LOG="${LOG_DIR}"/startup_stderr.log
 
+<% if_p("rabbitmq-server.additional_plugin_dir") do |dir| %>
+export RABBITMQ_PLUGINS_DIR=/var/vcap/packages/rabbitmq-server/plugins/:<%= dir %>
+<% end %>
+
 test -x "${DAEMON}"
 test -x "${CONTROL}"
 test -x "${START_PROG}"


### PR DESCRIPTION
This allows people to create small bosh-releases that contain additional plugins (say, https://github.com/deadtrickster/prometheus_rabbitmq_exporter for example) and add them to their rabbitmq deployment without needing to modify the upstream rabbitmq release at all.