### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -11,10 +11,10 @@ golang/go1.11.4.linux-amd64.tar.gz:
   size: 126643341
   object_id: 846b3fe5-f2a6-4aae-64b1-61093f6f4f60
   sha: sha256:fb26c30e6a04ad937bbc657a1b5bba92f80096af1e8ee6da6430c045a8db3a5b
-haproxy/haproxy-1.6.14.tar.gz:
-  size: 1583859
-  object_id: 7194fe65-b76c-42b8-6106-7f7f26e26e33
-  sha: sha256:bac949838a3a497221d1a9e937d60cba32156783a216146a524ce40675b6b828
+haproxy/haproxy-1.8.16.tar.gz:
+  size: 2076646
+  object_id: 3b20352b-0c9f-400b-58e6-0307e010e54f
+  sha: sha256:5401e4ad243d9e403621e389ec3605d8d43241affe0b72f0b15c0db8a7a3653f
 rabbitmq-server-3.6/rabbitmq-server-generic-unix-3.6.16.tar.xz:
   size: 4808464
   object_id: b9575b38-5483-44bb-4c4a-58de00155fb5

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="1.6.14"
+VERSION="1.8.16"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 1.6.14
+  version: 1.8.16
 files:
-- haproxy/haproxy-1.6.14.tar.gz
+- haproxy/haproxy-1.8.16.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 1.8.16