### PR TITLE
Update vendored Go modules for pivotal-cf/cf-rabbitmq-release

### DIFF
--- a/src/rabbitmq-admin/go.mod
+++ b/src/rabbitmq-admin/go.mod
@@ -5,10 +5,10 @@ require (
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
 	github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec
-	golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664 // indirect
+	golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 // indirect
 	golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3 // indirect
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
-	golang.org/x/sys v0.0.0-20190130150945-aca44879d564 // indirect
+	golang.org/x/sys v0.0.0-20190203050204-7ae0202eb74c // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/src/rabbitmq-admin/go.sum
+++ b/src/rabbitmq-admin/go.sum
@@ -27,6 +27,8 @@ golang.org/x/crypto v0.0.0-20190129210102-ccddf3741a0c h1:MWY7h75sb9ioBR+s5Zgq1J
 golang.org/x/crypto v0.0.0-20190129210102-ccddf3741a0c/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664 h1:YbZJ76lQ1BqNhVe7dKTSB67wDrc2VPRR75IyGyyPDX8=
 golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613 h1:MQ/ZZiDsUapFFiMS+vzwXkCTeEKaum+Do5rINYJDmxc=
+golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd h1:nTDtHvHSdCn1m6ITfMRqtOd/9+7a3s8RBNOZ3eYZzJA=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190110200230-915654e7eabc h1:Yx9JGxI1SBhVLFjpAkWMaO1TF+xyqtHLjZpvQboJGiM=
@@ -57,6 +59,8 @@ golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc h1:WiYx1rIFmx8c0mXAFtv5D/mHy
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190130150945-aca44879d564 h1:o6ENHFwwr1TZ9CUPQcfo1HGvLP1OPsPOTB7xCIOPNmU=
 golang.org/x/sys v0.0.0-20190130150945-aca44879d564/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190203050204-7ae0202eb74c h1:YeMXU0KQqExdpG959DFhAhfpY8myIsnfqj8lhNFRzzE=
+golang.org/x/sys v0.0.0-20190203050204-7ae0202eb74c/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/mkerrors.sh
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/mkerrors.sh
@@ -482,6 +482,7 @@ ccflags="$@"
 		$2 ~ /^ALG_/ ||
 		$2 ~ /^FS_(POLICY_FLAGS|KEY_DESC|ENCRYPTION_MODE|[A-Z0-9_]+_KEY_SIZE|IOC_(GET|SET)_ENCRYPTION)/ ||
 		$2 ~ /^GRND_/ ||
+		$2 ~ /^RND/ ||
 		$2 ~ /^KEY_(SPEC|REQKEY_DEFL)_/ ||
 		$2 ~ /^KEYCTL_/ ||
 		$2 ~ /^PERF_EVENT_IOC_/ ||

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
@@ -1537,6 +1537,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x40085203
+	RNDADDTOENTCNT                       = 0x40045201
+	RNDCLEARPOOL                         = 0x5206
+	RNDGETENTCNT                         = 0x80045200
+	RNDGETPOOL                           = 0x80085202
+	RNDRESEEDCRNG                        = 0x5207
+	RNDZAPENTCNT                         = 0x5204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
@@ -1538,6 +1538,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x40085203
+	RNDADDTOENTCNT                       = 0x40045201
+	RNDCLEARPOOL                         = 0x5206
+	RNDGETENTCNT                         = 0x80045200
+	RNDGETPOOL                           = 0x80085202
+	RNDRESEEDCRNG                        = 0x5207
+	RNDZAPENTCNT                         = 0x5204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
@@ -1544,6 +1544,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x40085203
+	RNDADDTOENTCNT                       = 0x40045201
+	RNDCLEARPOOL                         = 0x5206
+	RNDGETENTCNT                         = 0x80045200
+	RNDGETPOOL                           = 0x80085202
+	RNDRESEEDCRNG                        = 0x5207
+	RNDZAPENTCNT                         = 0x5204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
@@ -1528,6 +1528,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x40085203
+	RNDADDTOENTCNT                       = 0x40045201
+	RNDCLEARPOOL                         = 0x5206
+	RNDGETENTCNT                         = 0x80045200
+	RNDGETPOOL                           = 0x80085202
+	RNDRESEEDCRNG                        = 0x5207
+	RNDZAPENTCNT                         = 0x5204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
@@ -1537,6 +1537,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x80085203
+	RNDADDTOENTCNT                       = 0x80045201
+	RNDCLEARPOOL                         = 0x20005206
+	RNDGETENTCNT                         = 0x40045200
+	RNDGETPOOL                           = 0x40085202
+	RNDRESEEDCRNG                        = 0x20005207
+	RNDZAPENTCNT                         = 0x20005204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
@@ -1537,6 +1537,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x80085203
+	RNDADDTOENTCNT                       = 0x80045201
+	RNDCLEARPOOL                         = 0x20005206
+	RNDGETENTCNT                         = 0x40045200
+	RNDGETPOOL                           = 0x40085202
+	RNDRESEEDCRNG                        = 0x20005207
+	RNDZAPENTCNT                         = 0x20005204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
@@ -1537,6 +1537,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x80085203
+	RNDADDTOENTCNT                       = 0x80045201
+	RNDCLEARPOOL                         = 0x20005206
+	RNDGETENTCNT                         = 0x40045200
+	RNDGETPOOL                           = 0x40085202
+	RNDRESEEDCRNG                        = 0x20005207
+	RNDZAPENTCNT                         = 0x20005204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
@@ -1537,6 +1537,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x80085203
+	RNDADDTOENTCNT                       = 0x80045201
+	RNDCLEARPOOL                         = 0x20005206
+	RNDGETENTCNT                         = 0x40045200
+	RNDGETPOOL                           = 0x40085202
+	RNDRESEEDCRNG                        = 0x20005207
+	RNDZAPENTCNT                         = 0x20005204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
@@ -1595,6 +1595,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x80085203
+	RNDADDTOENTCNT                       = 0x80045201
+	RNDCLEARPOOL                         = 0x20005206
+	RNDGETENTCNT                         = 0x40045200
+	RNDGETPOOL                           = 0x40085202
+	RNDRESEEDCRNG                        = 0x20005207
+	RNDZAPENTCNT                         = 0x20005204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
@@ -1595,6 +1595,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x80085203
+	RNDADDTOENTCNT                       = 0x80045201
+	RNDCLEARPOOL                         = 0x20005206
+	RNDGETENTCNT                         = 0x40045200
+	RNDGETPOOL                           = 0x40085202
+	RNDRESEEDCRNG                        = 0x20005207
+	RNDZAPENTCNT                         = 0x20005204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
@@ -1525,6 +1525,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x40085203
+	RNDADDTOENTCNT                       = 0x40045201
+	RNDCLEARPOOL                         = 0x5206
+	RNDGETENTCNT                         = 0x80045200
+	RNDGETPOOL                           = 0x80085202
+	RNDRESEEDCRNG                        = 0x5207
+	RNDZAPENTCNT                         = 0x5204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
@@ -1598,6 +1598,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x40085203
+	RNDADDTOENTCNT                       = 0x40045201
+	RNDCLEARPOOL                         = 0x5206
+	RNDGETENTCNT                         = 0x80045200
+	RNDGETPOOL                           = 0x80085202
+	RNDRESEEDCRNG                        = 0x5207
+	RNDZAPENTCNT                         = 0x5204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
@@ -1590,6 +1590,13 @@ const (
 	RLIMIT_SIGPENDING                    = 0xb
 	RLIMIT_STACK                         = 0x3
 	RLIM_INFINITY                        = 0xffffffffffffffff
+	RNDADDENTROPY                        = 0x80085203
+	RNDADDTOENTCNT                       = 0x80045201
+	RNDCLEARPOOL                         = 0x20005206
+	RNDGETENTCNT                         = 0x40045200
+	RNDGETPOOL                           = 0x40085202
+	RNDRESEEDCRNG                        = 0x20005207
+	RNDZAPENTCNT                         = 0x20005204
 	RTAX_ADVMSS                          = 0x8
 	RTAX_CC_ALGO                         = 0x10
 	RTAX_CWND                            = 0x7

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
@@ -779,8 +779,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x80045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
@@ -792,8 +792,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x80045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
@@ -768,8 +768,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x80045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
@@ -771,8 +771,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x80045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
@@ -773,8 +773,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x40045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
@@ -773,8 +773,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x40045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
@@ -773,8 +773,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x40045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
@@ -773,8 +773,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x40045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
@@ -781,8 +781,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x40045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
@@ -781,8 +781,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x40045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
@@ -798,8 +798,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x80045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
@@ -794,8 +794,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x80045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
+++ b/src/rabbitmq-admin/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
@@ -776,8 +776,6 @@ type SignalfdSiginfo struct {
 	_       [48]uint8
 }
 
-const RNDGETENTCNT = 0x40045200
-
 const PERF_IOC_FLAG_GROUP = 0x1
 
 type Termios struct {

--- a/src/rabbitmq-admin/vendor/modules.txt
+++ b/src/rabbitmq-admin/vendor/modules.txt
@@ -41,13 +41,13 @@ github.com/onsi/gomega/matchers/support/goraph/util
 # github.com/vito/go-interact v0.0.0-20171111012221-fa338ed9e9ec
 github.com/vito/go-interact/interact
 github.com/vito/go-interact/interact/terminal
-# golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664
+# golang.org/x/crypto v0.0.0-20190131182504-b8fe1690c613
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
 golang.org/x/net/html/charset
 golang.org/x/net/html
 golang.org/x/net/html/atom
-# golang.org/x/sys v0.0.0-20190130150945-aca44879d564
+# golang.org/x/sys v0.0.0-20190203050204-7ae0202eb74c
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 # golang.org/x/text v0.3.0


### PR DESCRIPTION
This PR updates the vendored Go modules of pivotal-cf/cf-rabbitmq-release