### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -11,10 +11,10 @@ golang/go1.11.5.linux-amd64.tar.gz:
   size: 140132627
   object_id: 4cf41b9a-acf4-4f00-4f78-c6c95a4b074b
   sha: sha256:ff54aafedff961eb94792487e827515da683d61a5f9482f668008832631e5d25
-haproxy/haproxy-1.8.19.tar.gz:
-  size: 2080757
-  object_id: 2ec3d7bf-870e-4c49-6b57-3c058642f349
-  sha: sha256:64f5fbfd4e09ffeaf26cb6667398ba780704a14e96e60000caa8bf69962ba734
+haproxy/haproxy-1.8.20.tar.gz:
+  size: 2083917
+  object_id: 71408931-a167-4faa-623d-d5759178cf59
+  sha: sha256:3228f78d5fe1dfbaccf41bf387e36b08eeef6e16330053cafde5fa303e262b16
 rabbitmq-server-3.7/rabbitmq-server-generic-unix-3.7.14.tar.xz:
   size: 9492032
   object_id: a30cbc6f-787b-4f9c-4b4a-0b36f2776701

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="1.8.19"
+VERSION="1.8.20"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 1.8.19
+  version: 1.8.20
 files:
-- haproxy/haproxy-1.8.19.tar.gz
+- haproxy/haproxy-1.8.20.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 1.8.20