### PR TITLE
Update rabbitmq-server-3.7 package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,7 +15,3 @@ haproxy/haproxy-1.8.19.tar.gz:
   size: 2080757
   object_id: 2ec3d7bf-870e-4c49-6b57-3c058642f349
   sha: sha256:64f5fbfd4e09ffeaf26cb6667398ba780704a14e96e60000caa8bf69962ba734
-rabbitmq-server-3.7/rabbitmq-server-generic-unix-3.7.14.tar.xz:
-  size: 9492032
-  object_id: a30cbc6f-787b-4f9c-4b4a-0b36f2776701
-  sha: sha256:f036f3abb4c37f1dbaa62042e2358b255a535e4c04b3a573d2e2e991748411c3


### PR DESCRIPTION
This PR updates the version of rabbitmq-server-3.7 to 3.7.14