### PR TITLE
Update golang package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,4 +1,3 @@
----
 basht/basht_0.1.0_Linux_x86_64.tgz:
   size: 757703
   object_id: bbc2200b-670b-4562-72db-27ce98bc3161
@@ -11,6 +10,9 @@ golang/go1.12.7.linux-amd64.tar.gz:
   size: 127959471
   object_id: be80d547-5e2e-4625-408c-0b0d7ecdbf6e
   sha: sha256:66d83bfb5a9ede000e33c6579a91a29e6b101829ad41fffb5c5bb6c900e109d9
+golang/go1.12.8.linux-amd64.tar.gz:
+  size: 127961104
+  sha: sha256:bd26cd4962a362ed3c11835bca32c2e131c2ae050304f2c4df9fa6ded8db85d2
 haproxy/haproxy-1.8.20.tar.gz:
   size: 2083917
   object_id: 71408931-a167-4faa-623d-d5759178cf59


### PR DESCRIPTION
This PR updates the version of golang to 1.12.8