### PR TITLE
Update rabbitmq-server-3.8-alpha package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -19,7 +19,7 @@ rabbitmq-server-3.7/rabbitmq-server-generic-unix-3.7.17.tar.xz:
   size: 9982364
   object_id: 2a86af8f-55e4-4a13-7b9a-33b4ca55c761
   sha: sha256:83abd26dc2f27ea6eee85324163aecd36f1b861e58a027df83f631cbd89ead5d
-rabbitmq-server-3.8-alpha/rabbitmq-server-generic-unix-3.8.0-alpha.863.tar.xz:
-  size: 11584800
-  object_id: b599d861-3efd-4c5b-6c38-ece0a820b417
-  sha: sha256:449d8b442c1e30de4487ff2d91aa40764b5db3a35f5f15ae234c96b39a5abe2b
+rabbitmq-server-3.8-alpha/rabbitmq-server-generic-unix-3.8.0-alpha.864.tar.xz:
+  size: 11586960
+  object_id: 64156fe8-064e-4aa8-7543-008dd053d80f
+  sha: sha256:9a88422d93c6fdd4d0d684231cf178137976629fc9c0991e2d07e35069f152c1

--- a/packages/rabbitmq-server-3.8-alpha/packaging
+++ b/packages/rabbitmq-server-3.8-alpha/packaging
@@ -2,7 +2,7 @@
 
 set -e
 
-RMQ_VERSION="3.8.0-alpha.863"
+RMQ_VERSION="3.8.0-alpha.864"
 RMQ_VERSION_SEMVER="3.8.0"
 ERLANG_VERSION="21.3"
 RABBITMQ_SERVER_PATH="rabbitmq-server-3.8-alpha"

--- a/packages/rabbitmq-server-3.8-alpha/spec
+++ b/packages/rabbitmq-server-3.8-alpha/spec
@@ -1,9 +1,9 @@
 ---
 name: rabbitmq-server-3.8-alpha
 metadata:
-  version: 3.8.0-alpha.863
+  version: 3.8.0-alpha.864
 files:
-- rabbitmq-server-3.8-alpha/rabbitmq-server-generic-unix-3.8.0-alpha.863.tar.xz
+- rabbitmq-server-3.8-alpha/rabbitmq-server-generic-unix-3.8.0-alpha.864.tar.xz
 - rabbitmq-server/rabbitmq-script-wrapper
 - rabbitmq-server/rabbitmq-defaults
 dependencies: []


### PR DESCRIPTION
This PR updates the version of rabbitmq-server-3.8-alpha to 3.8.0-alpha.864