### PR TITLE
Update rabbitmq-server-3.8-alpha package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -19,7 +19,7 @@ rabbitmq-server-3.7/rabbitmq-server-generic-unix-3.7.17.tar.xz:
   size: 9982364
   object_id: 2a86af8f-55e4-4a13-7b9a-33b4ca55c761
   sha: sha256:83abd26dc2f27ea6eee85324163aecd36f1b861e58a027df83f631cbd89ead5d
-rabbitmq-server-3.8-alpha/rabbitmq-server-generic-unix-3.8.0-alpha.867.tar.xz:
-  size: 11586104
-  object_id: e1e01877-2cf6-4c0f-594b-c7b36dc31c43
-  sha: sha256:ed4a1f0a8f83b27fac82fbf812419c169dbd2126b86a7865bda67e35adfb7c8a
+rabbitmq-server-3.8-alpha/rabbitmq-server-generic-unix-3.8.0-rc.1.tar.xz:
+  size: 11574532
+  object_id: 8ebd93b8-3aa3-4352-5cb3-60baa58b4336
+  sha: sha256:a03fcb959d7739c993c02cae94e2a4a15721e7fb1e98eed095e6ed0aeba3045a

--- a/packages/rabbitmq-server-3.8-alpha/packaging
+++ b/packages/rabbitmq-server-3.8-alpha/packaging
@@ -2,7 +2,7 @@
 
 set -e
 
-RMQ_VERSION="3.8.0-alpha.867"
+RMQ_VERSION="3.8.0-rc.1"
 RMQ_VERSION_SEMVER="3.8.0"
 ERLANG_VERSION="21.3"
 RABBITMQ_SERVER_PATH="rabbitmq-server-3.8-alpha"

--- a/packages/rabbitmq-server-3.8-alpha/spec
+++ b/packages/rabbitmq-server-3.8-alpha/spec
@@ -1,9 +1,9 @@
 ---
 name: rabbitmq-server-3.8-alpha
 metadata:
-  version: 3.8.0-alpha.867
+  version: 3.8.0-rc.1
 files:
-- rabbitmq-server-3.8-alpha/rabbitmq-server-generic-unix-3.8.0-alpha.867.tar.xz
+- rabbitmq-server-3.8-alpha/rabbitmq-server-generic-unix-3.8.0-rc.1.tar.xz
 - rabbitmq-server/rabbitmq-script-wrapper
 - rabbitmq-server/rabbitmq-defaults
 dependencies: []


### PR DESCRIPTION
This PR updates the version of rabbitmq-server-3.8-alpha to 3.8.0-rc.1