### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -20,10 +20,10 @@ golang/go1.14.1.linux-amd64.tar.gz:
   object_id: ac5b5718-3b44-43fb-55a9-babc275c1dfc
   sha: sha256:2f49eb17ce8b48c680cdb166ffd7389702c0dec6effa090c324804a5cac8a7f8
 # this comment prevents git conflicts
-haproxy/haproxy-1.8.24.tar.gz:
-  size: 2178823
-  object_id: cb74ba09-a3f6-4689-67bb-d2a3a8852180
-  sha: sha256:da4bc3db58105f2016a706b5c0242a6c870266c69581146ac7c363210604771a
+haproxy/haproxy-1.8.25.tar.gz:
+  size: 2184002
+  object_id: 47b0cf98-47e9-4c26-7aca-17f010ea99e4
+  sha: sha256:62c0b77de2275a54a443a869947ddcca2bad7bdc1cafd804732a0e0d59b1708b
 # this comment prevents git conflicts
 rabbitmq-server-3.7/rabbitmq-server-generic-unix-3.7.24.tar.xz:
   size: 10059652

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="1.8.24"
+VERSION="1.8.25"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 1.8.24
+  version: 1.8.25
 files:
-- haproxy/haproxy-1.8.24.tar.gz
+- haproxy/haproxy-1.8.25.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 1.8.25