### PR TITLE
Render STOMP-over-WebSockets SSL config

### DIFF
--- a/jobs/rabbitmq-server/templates/rabbitmq.conf.erb
+++ b/jobs/rabbitmq-server/templates/rabbitmq.conf.erb
@@ -1,3 +1,23 @@
 <% if_p('rabbitmq-server.load_definitions') do -%>
 load_definitions = /var/vcap/jobs/rabbitmq-server/etc/definitions.json
 <% end -%>
+<% if_p('rabbitmq-server.ssl.enabled', 'rabbitmq-server.plugins') do |ssl_enabled, plugins|
+if ssl_enabled && plugins.include?('rabbitmq_web_stomp') -%>
+web_stomp.ssl.port = 15673
+web_stomp.ssl.cacertfile = /var/vcap/jobs/rabbitmq-server/etc/cacert.pem
+web_stomp.ssl.certfile = /var/vcap/jobs/rabbitmq-server/etc/cert.pem
+web_stomp.ssl.keyfile = /var/vcap/jobs/rabbitmq-server/etc/key.pem
+web_stomp.ssl.depth = <%= p('rabbitmq-server.ssl.verification_depth') %>
+<% p('rabbitmq-server.ssl.versions').each_with_index do | version, index | -%>
+web_stomp.ssl.versions.<%= index+1 %> = <%= version %>
+<% end -%>
+<% if p('rabbitmq-server.ssl.disable_non_ssl_listeners') -%>
+web_stomp.tcp.listener = none
+<% end -%>
+<% if_p('rabbitmq-server.ssl.ciphers') do |ciphers|
+ciphers.each_with_index do |cipher, index| -%>
+web_stomp.ssl.ciphers.<%= index+1 %> = <%= cipher %>
+<% end
+end
+end
+end -%>

--- a/spec/unit/templates/rabbitmq_conf_spec.rb
+++ b/spec/unit/templates/rabbitmq_conf_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Configuration', template: true do
       }
     end
     it 'renders load_definition path' do
-      expect(rendered_template).to include("load_definitions = /var/vcap/jobs/rabbitmq-server/etc/definitions.json")
+      expect(rendered_template).to include('load_definitions = /var/vcap/jobs/rabbitmq-server/etc/definitions.json')
     end
   end
 
@@ -27,6 +27,55 @@ RSpec.describe 'Configuration', template: true do
     let(:manifest_properties) { {} }
     it 'renders an empty rabbitmq.conf file' do
       expect(rendered_template).to be_empty
+    end
+  end
+
+  context 'when rabbitmq_web_stomp plugin and SSL are enabled' do
+    let(:manifest_properties) do
+      {
+        'rabbitmq-server' => {
+          'plugins' => ['rabbitmq_web_stomp'],
+          'ssl' => {
+            'enabled' => true,
+            'cacert' => 'fake CA cert',
+            'cert' => 'fake cert',
+            'key' => 'fake key',
+            'verification_depth' => 3,
+            'versions' => ['tlsv1.2','tlsv1.1'],
+            'disable_non_ssl_listeners' => false,
+          }
+        }
+      }
+    end
+    it 'renders web_stomp config' do
+      expect(rendered_template).to include('web_stomp.ssl.port = 15673')
+      expect(rendered_template).to include('web_stomp.ssl.cacertfile = /var/vcap/jobs/rabbitmq-server/etc/cacert.pem')
+      expect(rendered_template).to include('web_stomp.ssl.certfile = /var/vcap/jobs/rabbitmq-server/etc/cert.pem')
+      expect(rendered_template).to include('web_stomp.ssl.keyfile = /var/vcap/jobs/rabbitmq-server/etc/key.pem')
+      expect(rendered_template).to include('web_stomp.ssl.depth = 3')
+      expect(rendered_template).to include('web_stomp.ssl.versions.1 = tlsv1.2')
+      expect(rendered_template).to include('web_stomp.ssl.versions.2 = tlsv1.1')
+      expect(rendered_template).not_to include('web_stomp.tcp.listener')
+      expect(rendered_template).not_to include('web_stomp.ssl.ciphers')
+    end
+
+    context 'when disable_non_ssl_listeners is true' do
+      before do
+        manifest_properties['rabbitmq-server']['ssl']['disable_non_ssl_listeners'] = true
+      end
+      it 'disables STOMP TCP listeners' do
+        expect(rendered_template).to include('web_stomp.tcp.listener = none')
+      end
+    end
+
+    context 'when ciphers are set' do
+      before do
+        manifest_properties['rabbitmq-server']['ssl']['ciphers'] = ['cipher1', 'cipher2']
+      end
+      it 'renders STOMP SSL ciphers' do
+        expect(rendered_template).to include('web_stomp.ssl.ciphers.1 = cipher1')
+        expect(rendered_template).to include('web_stomp.ssl.ciphers.2 = cipher2')
+      end
     end
   end
 end


### PR DESCRIPTION
Render Web STOMP SSL config if `rabbitmq_web_stomp` plugin is enabled and SSL is enabled.

[#174865958]