### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -20,10 +20,10 @@ golang/go1.15.3.linux-amd64.tar.gz:
   object_id: ba0c9ed4-9793-4704-69da-0caa5f766e79
   sha: sha256:010a88df924a81ec21b293b5da8f9b11c176d27c0ee3962dc1738d2352d3c02d
 # this comment prevents git conflicts
-haproxy/haproxy-1.8.26.tar.gz:
-  size: 2205531
-  object_id: 4adf741e-574f-4947-5f40-ed94cb95aa77
-  sha: sha256:e3c2a81b6f26dcb736a34ebb5f134d3251ceccf30386214655fa7ed6d3afa400
+haproxy/haproxy-1.8.27.tar.gz:
+  size: 2209243
+  object_id: c75033fc-c2eb-4b9a-7625-da6d299cad15
+  sha: sha256:56ba6a21e13215fae56472ad37d5d68c3f19bde9da94c59e70b869eecf48bf50
 # this comment prevents git conflicts
 rabbitmq-server-3.8/rabbitmq-server-generic-unix-3.8.9.tar.xz:
   size: 15361208

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="1.8.26"
+VERSION="1.8.27"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 1.8.26
+  version: 1.8.27
 files:
-- haproxy/haproxy-1.8.26.tar.gz
+- haproxy/haproxy-1.8.27.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 1.8.27