### PR TITLE
Additional main config properties as key/value map in manifest

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -122,7 +122,7 @@ properties:
     description: "If true, configure rabbitmq-server to use vm_strategy create-swap-delete (i.e. use RabbitMQ long node names, FQDNs for Rabbit nodes names, and no hosts in erl_inetrc)."
     default: false
 
-  rabbitmq-server:additional_main_conf:
+  rabbitmq-server.additional_main_conf:
     description: "A map of additional key/value pairs to include as extra configuration properties in the main configuration file, rabbitmq.conf https://www.rabbitmq.com/configure.html#config-file"
     default: { }
     example: |

--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -122,6 +122,14 @@ properties:
     description: "If true, configure rabbitmq-server to use vm_strategy create-swap-delete (i.e. use RabbitMQ long node names, FQDNs for Rabbit nodes names, and no hosts in erl_inetrc)."
     default: false
 
+  rabbitmq-server:additional_main_conf:
+    description: "A map of additional key/value pairs to include as extra configuration properties in the main configuration file, rabbitmq.conf https://www.rabbitmq.com/configure.html#config-file"
+    default: { }
+    example: |
+      "listeners.tcp.default": "5673"
+      "prometheus.return_per_object_metrics": "true"
+
+
 templates:
   add-rabbitmqctl-to-path.bash:             bin/add-rabbitmqctl-to-path
   cleanup-http-logs.bash:                   bin/cleanup-http-logs

--- a/jobs/rabbitmq-server/templates/rabbitmq.conf.erb
+++ b/jobs/rabbitmq-server/templates/rabbitmq.conf.erb
@@ -20,9 +20,7 @@ web_stomp.ssl.ciphers.<%= index+1 %> = <%= cipher %>
 <% end
 end
 end
-end -%>
-<% if_p("rabbitmq-server.additional_main_conf") do |add_cfg| %>
+end -%><% if_p("rabbitmq-server.additional_main_conf") do |add_cfg| %>
 <% add_cfg.each do |key, value| %>
 <%= key %> = <%= value %>
-<% end %>
-<% end %>
+<% end %><% end %>

--- a/jobs/rabbitmq-server/templates/rabbitmq.conf.erb
+++ b/jobs/rabbitmq-server/templates/rabbitmq.conf.erb
@@ -21,3 +21,8 @@ web_stomp.ssl.ciphers.<%= index+1 %> = <%= cipher %>
 end
 end
 end -%>
+<% if_p("rabbitmq-server.additional_main_conf") do |add_cfg| %>
+<% add_cfg.each do |key, value| %>
+<%= key %> = <%= value %>
+<% end %>
+<% end %>


### PR DESCRIPTION
I want to enable `prometheus_exporter` plugin to get individual (per object, not aggregated) metrics.
To do this I have to change [the following options](https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_prometheus/README.md#configuration) in [the main config file](https://www.rabbitmq.com/configure.html#config-file):
```
prometheus.return_per_object_metrics = true
```

To support cases like this I propose to add the new property `rabbitmq-server.additional_main_conf` - a map of additional key/value pairs to include as extra configuration properties in the main configuration file.

After this I can create ops to get what I originally wanted to achieve:
```yaml
- type: replace
  path: /instance_groups/name=rmq/jobs/name=rabbitmq-server/properties/rabbitmq-server/plugins/-
  value: rabbitmq_prometheus

- type: replace
  path: /instance_groups/name=rmq/jobs/name=rabbitmq-server/properties/rabbitmq-server/additional_main_conf?/prometheus.return_per_object_metrics?
  value: "true"
```