### PR TITLE
Package openssl 1.1.1 and build Erlang against it

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -25,6 +25,11 @@ haproxy/haproxy-1.8.28.tar.gz:
   object_id: 3172c51f-6cb5-4b67-5215-f3a909b7f2c0
   sha: sha256:fecf031486014d5838499f69cba0348abffa076e55f6fadf86a8da93cbf94e89
 # this comment prevents git conflicts
+openssl/openssl-1.1.1i.tar.gz:
+  size: 9808346
+  object_id: ee07e0f6-bc01-48d7-496b-c1516e6e1f0c
+  sha: sha256:e8be6a35fe41d10603c3cc635e93289ed00bf34b79671a3a4de64fcee00d5242
+# this comment prevents git conflicts
 rabbitmq-server-3.8/rabbitmq-server-generic-unix-3.8.11.tar.xz:
   size: 15644332
   object_id: 59ce2d8a-73b4-49a3-5045-e586d0096b73

--- a/config/private.yml.example
+++ b/config/private.yml.example
@@ -1,5 +1,5 @@
 # get the values from the output of
-# lpass show "Shared-London Services/london-ci/aws-keys"
+# lpass show "Shared-PCF RabbitMQ/Concourse Pipelines/bosh-release-pipeline-secrets"
 #
 # After filling in the values move this file to config/private.yml
 #

--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -7,6 +7,7 @@ packages:
 - rabbitmq-common
 - rabbitmq-upgrade-preparation
 - rabbitmq-admin
+- openssl
 
 properties:
   rabbitmq-server.version:

--- a/packages/erlang-23/packaging
+++ b/packages/erlang-23/packaging
@@ -2,13 +2,19 @@ set -e
 
 export HOME=${BOSH_INSTALL_DIR}
 
+cpus="$(grep -c ^processor /proc/cpuinfo)"
+
 VERSION="23.2.3"
 MAJOR_VERSION="23"
 echo "$MAJOR_VERSION" > "$BOSH_INSTALL_TARGET/erlang_version"
 
 tar xzf erlang-23/otp_src_oss_${VERSION}.tgz
 cd otp_src_oss_${VERSION}
-./configure --prefix=${BOSH_INSTALL_TARGET}
-make
+./configure \
+  --with-ssl="/var/vcap/packages/openssl/external/openssl/" \
+  --with-ssl-rpath="/var/vcap/packages/openssl/external/openssl/lib/" \
+  --prefix=${BOSH_INSTALL_TARGET}
+
+make -j$cpus
 make install
 

--- a/packages/erlang-23/spec
+++ b/packages/erlang-23/spec
@@ -4,4 +4,5 @@ metadata:
   version: 23.2.3
 files:
 - erlang-23/otp_src_oss_23.2.3.tgz
-dependencies: []
+dependencies:
+- openssl

--- a/packages/openssl/packaging
+++ b/packages/openssl/packaging
@@ -1,0 +1,18 @@
+set -ex
+
+cpus="$(grep -c ^processor /proc/cpuinfo)"
+
+cd openssl/
+
+tar -xf openssl-1.1.1i.tar.gz
+cd openssl-1.1.1i
+
+./config \
+  --shared \
+  -Wl,-rpath="${BOSH_INSTALL_TARGET}/external/openssl/lib" \
+  --prefix="${BOSH_INSTALL_TARGET}/external/openssl" \
+  --openssldir="${BOSH_INSTALL_TARGET}/external/openssldir"
+
+
+make -j$cpus
+make install

--- a/packages/openssl/spec
+++ b/packages/openssl/spec
@@ -1,0 +1,7 @@
+---
+name: openssl
+
+dependencies: []
+
+files:
+- openssl/openssl-1.1.1i.tar.gz


### PR DESCRIPTION
## The Problem

The stemcell (currently Xenial 621.99) installs version 1.0.2g of openssl. 

This causes the following error in RabbitMQ when TLS 1.3 is enabled:
```
2021-01-27 16:50:52.466 [error] <0.1422.0> Failed to start Ranch listener {acceptor,{0,0,0,0},8883} in ranch_ssl:listen([{cacerts,'...'},{key,'...'},{cert,'...'},{ip,{0,0,0,0}},{port,8883},inet,{backlog,128},{nodelay,true},{versions,['tlsv1.3']},{cacertfile,"/var/vcap/jobs/rabbitmq-server/bin/../etc/cacert.pem"},{certfile,"/var/vcap/jobs/rabbitmq-server/bin/../etc/cert.pem"},{keyfile,"/var/vcap/jobs/rabbitmq-server/bin/../etc/key.pem"},{verify,verify_peer},{depth,10},{fail_if_no_peer_cert,true}]) for reason {options,{insufficient_crypto_support,{'tlsv1.3',{versions,['tlsv1.3']}}}} (unknown POSIX error)
```

Notice the `insufficient_crypto_support` error at the very end of the log line.

This is because Erlang relies on openssl for certain encryption/decryption modules, and the version of openssl that comes with the stemcell does not support these for TLS 1.3.

## Solution

As a result of these changes, we will be packaging openssl 1.1.1 ourselves, and building Erlang against it. 

Note that this does add around 5 mins more to deploying the release. This is despite speeding up the building process by running it in parallel across the available cpus on the compilation machine.

## Tests

### Manual:

The code has been tested by deploying the cf-rabbitmq release with TLS v1.3 enabled, and checking TLS v1.3 using
-  `openssl s_client -connect localhost:5671`
- `	erl -noshell -eval 'io:format("~p~n~n~p~n~n", [crypto:supports(), ssl:versions()]), init:stop().'
`. 
Source: [Community Docker image build script](https://github.com/docker-library/rabbitmq/blob/2ee8b3bdeefbea1544326ccf2aadf1ae067659b1/Dockerfile-ubuntu.template#L200-L201)

### CI

We have an [integration test](https://github.com/pivotal-cf/cf-rabbitmq-release/blob/a5522c9c1661572afc5df6d38e26bc1f050dc0b9/spec/integration/rabbitmq_server_spec.rb#L151) that also runs `openssls_client -{tls-version} -connect localhost:5671`.

## Further work

Consider adding the openssl package to package bumper.