### PR TITLE
TLS 1.3 without TLS 1.1 or TLS 1.2

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -24,7 +24,7 @@ properties:
   rabbitmq-server.ssl.key:
     description: "RabbitMQ server private key"
   rabbitmq-server.ssl.versions:
-    description: "TLS protocol versions to support"
+    description: "TLS protocol versions to support. Note that TLS 1.3 is incompatible with TLS 1.1 and TLS 1.0. The deployment will fail if TLS 1.3 is enabled alongside TLS 1.0 or TLS 1.1."
     default: ['tlsv1.3','tlsv1.2']
   rabbitmq-server.ssl.ciphers:
     description: "TLS ciphers to use"

--- a/jobs/rabbitmq-server/templates/setup-vars.bash.erb
+++ b/jobs/rabbitmq-server/templates/setup-vars.bash.erb
@@ -23,7 +23,7 @@
         raise "Expected rabbitmq-server.ssl.ciphers to be a collection"
 
       tls_ciphers = ciphers.map do |c|
-        /^[a-zA-Z0-9\-]+$/.match(c) or raise "#{c} is not a valid cipher suite"
+        /^[a-zA-Z0-9\-\_]+$/.match(c) or raise "#{c} is not a valid cipher suite"
         "\\\"#{c}\\\"".gsub(/^'+|'+$/, "'")
       end.join(',')
       tls_ciphers = ",{ciphers,[#{tls_ciphers}]}"

--- a/jobs/rabbitmq-server/templates/setup-vars.bash.erb
+++ b/jobs/rabbitmq-server/templates/setup-vars.bash.erb
@@ -11,6 +11,10 @@
       supported_tls_versions.include?(v) or
         raise "#{v} is a not supported tls version"
 
+    if tls_versions.include?('tlsv1.3') && (tls_versions.include?('tlsv1.1') || tls_versions.include?('tlsv1'))
+      raise "TLS 1.3 cannot be enabled along with TLS 1.1 and TLS 1.0"
+    end
+
       # make sure the erlang atom is quoted by one and
       # only one single quote
       "'#{v}'".gsub(/^'+|'+$/, "'")

--- a/spec/integration/rabbitmq_server_spec.rb
+++ b/spec/integration/rabbitmq_server_spec.rb
@@ -133,6 +133,19 @@ RSpec.describe 'RabbitMQ server configuration' do
       end
 
       context 'when tlsv1, tlsv1.1 and tlsv1.2 are enabled' do
+        before(:all) do
+          manifest = bosh.manifest
+
+          bosh.redeploy do |manifest|
+            rmq_properties = get_properties(manifest, 'rmq', 'rabbitmq-server')['rabbitmq-server']
+            rmq_properties['ssl']['versions'] = ['tlsv1.2', 'tlsv1.1', 'tlsv1']
+
+            tlsv1_compatible_cipher = 'ECDHE-RSA-AES256-SHA'
+            tlsv1_2_compatible_cipher = 'ECDHE-RSA-AES256-GCM-SHA384'
+            rmq_properties['ssl']['ciphers'] = [tlsv1_compatible_cipher, tlsv1_2_compatible_cipher]
+          end
+        end
+
         it 'should have TLS 1.0 enabled' do
           output = bosh.ssh(rmq_host, connect_using('tls1'))
 
@@ -167,7 +180,6 @@ RSpec.describe 'RabbitMQ server configuration' do
           manifest = bosh.manifest
 
           bosh.redeploy do |manifest|
-            # Change management creds
             rmq_properties = get_properties(manifest, 'rmq', 'rabbitmq-server')['rabbitmq-server']
             rmq_properties['ssl']['versions'] = ['tlsv1.3', 'tlsv1.2']
 

--- a/spec/integration/rabbitmq_server_spec.rb
+++ b/spec/integration/rabbitmq_server_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe 'RabbitMQ server configuration' do
     'sudo PATH=$PATH:/var/vcap/packages/erlang/bin/ /var/vcap/packages/rabbitmq-server/privbin/rabbitmq-diagnostics'
   end
 
+  def openssl
+    '/var/vcap/packages/openssl/external/openssl/bin/openssl'
+  end
+
   let(:environment_settings) do
     stdout(bosh.ssh(rmq_host, "#{rabbitmqctl} environment"))
   end
@@ -70,7 +74,7 @@ RSpec.describe 'RabbitMQ server configuration' do
         rmq_properties['ssl']['key'] = server_key
         rmq_properties['ssl']['cert'] = server_cert
         rmq_properties['ssl']['cacert'] = ca_cert
-        rmq_properties['ssl']['versions'] = ['tlsv1.3', 'tlsv1.2', 'tlsv1.1', 'tlsv1']
+        rmq_properties['ssl']['versions'] = ['tlsv1.2', 'tlsv1.1', 'tlsv1']
         rmq_properties['ssl']['disable_non_ssl_listeners'] = true
 
         tlsv1_compatible_cipher = 'ECDHE-RSA-AES256-SHA'
@@ -114,6 +118,10 @@ RSpec.describe 'RabbitMQ server configuration' do
     end
 
     describe 'SSL' do
+      def connect_using(tls_version)
+        "#{openssl} s_client -#{tls_version} -connect 127.0.0.1:5671"
+      end
+
       it 'enables SSL listeners' do
           output = bosh.ssh(rmq_host, "#{rabbitmq_diagnostics} listeners")
           # regex in order not to match the management api ssl port 15671
@@ -124,8 +132,7 @@ RSpec.describe 'RabbitMQ server configuration' do
           expect(stdout(output)).to match(amqp_ssl_port_regex)
       end
 
-
-      context 'when tlsv1, tlsv1.1, tlsv1.2 and tlsv1.3 are enabled' do
+      context 'when tlsv1, tlsv1.1 and tlsv1.2 are enabled' do
         it 'should have TLS 1.0 enabled' do
           output = bosh.ssh(rmq_host, connect_using('tls1'))
 
@@ -147,22 +154,40 @@ RSpec.describe 'RabbitMQ server configuration' do
           expect(stdout(output)).to include('END CERTIFICATE')
         end
 
-        it 'should have TLS 1.3 enabled' do
-          output = bosh.ssh(rmq_host, connect_using('tls1_3'))
-
-          expect(stdout(output)).to include('BEGIN CERTIFICATE')
-          expect(stdout(output)).to include('END CERTIFICATE')
-        end
-
-        def connect_using(tls_version)
-          "openssl s_client -#{tls_version} -connect 127.0.0.1:5671"
-        end
-
         context 'when client connects with a cipher not configured on the server' do
           it 'should not be able to connect' do
             output = bosh.ssh(rmq_host, 'openssl s_client -cipher AES256-SHA256 -connect 127.0.0.1:5671')
             expect(stdout(output)).to include('insufficient security')
           end
+        end
+      end
+
+      context 'when tlsv1.2 and tlsv1.3 are enabled' do
+        before(:all) do
+          manifest = bosh.manifest
+
+          bosh.redeploy do |manifest|
+            # Change management creds
+            rmq_properties = get_properties(manifest, 'rmq', 'rabbitmq-server')['rabbitmq-server']
+            rmq_properties['ssl']['versions'] = ['tlsv1.3', 'tlsv1.2']
+
+            tlsv1_2_compatible_cipher = 'ECDHE-RSA-AES256-GCM-SHA384'
+            tlsv1_3_compatible_cipher = 'TLS_AES_256_GCM_SHA384'
+            rmq_properties['ssl']['ciphers'] = [tlsv1_2_compatible_cipher, tlsv1_3_compatible_cipher]
+          end
+        end
+        it 'should have TLS 1.2 enabled' do
+          output = bosh.ssh(rmq_host, connect_using('tls1_2'))
+
+          expect(stdout(output)).to include('BEGIN CERTIFICATE')
+          expect(stdout(output)).to include('END CERTIFICATE')
+        end
+
+        it 'should have TLS 1.3 enabled' do
+          output = bosh.ssh(rmq_host, connect_using('tls1_3'))
+
+          expect(stdout(output)).to include('BEGIN CERTIFICATE')
+          expect(stdout(output)).to include('END CERTIFICATE')
         end
       end
 

--- a/spec/unit/templates/rabbitmq-server_setup-vars_spec.rb
+++ b/spec/unit/templates/rabbitmq-server_setup-vars_spec.rb
@@ -47,12 +47,22 @@ RSpec.describe 'setup-vars.bash file generation', template: true do
     end
 
     context 'when tls versions are configured' do
-      before :each do
+      it 'uses provided tls versions' do
         manifest_properties['rabbitmq-server']['ssl']['versions'] = ['tlsv1.2']
+
+        expect(output).to include "export SSL_SUPPORTED_TLS_VERSIONS=\"['tlsv1.2']\""
       end
 
-      it 'uses provided tls versions' do
-        expect(output).to include "export SSL_SUPPORTED_TLS_VERSIONS=\"['tlsv1.2']\""
+      context 'when tls 1.3 is enabled along with tls 1.1 or tls 1.0' do
+        it 'raises an error' do
+          manifest_properties['rabbitmq-server']['ssl']['versions'] = ['tlsv1.3', 'tlsv1.2', 'tlsv1.1']
+          expect { output }.to \
+            raise_error 'TLS 1.3 cannot be enabled along with TLS 1.1 and TLS 1.0'
+
+          manifest_properties['rabbitmq-server']['ssl']['versions'] = ['tlsv1.3', 'tlsv1.2', 'tlsv1.1', 'tls1.0']
+          expect { output }.to \
+            raise_error 'TLS 1.3 cannot be enabled along with TLS 1.1 and TLS 1.0'
+        end
       end
     end
 

--- a/spec/unit/templates/rabbitmq-server_setup-vars_spec.rb
+++ b/spec/unit/templates/rabbitmq-server_setup-vars_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'setup-vars.bash file generation', template: true do
 
     context 'when invalid tls ciphers are specified' do
       before :each do
-        manifest_properties['rabbitmq-server']['ssl']['ciphers'] = %w[SOME-valid-cipher-1232 an_invalid_!@#$]
+        manifest_properties['rabbitmq-server']['ssl']['ciphers'] = %w[SOME-valid-cipher-1232 TLS1_3_VALID_CIPHER an_invalid_!@#$]
       end
 
       it 'raise an error' do


### PR DESCRIPTION
Summary of changes:
- default TLS version: TLS 1.3 and TLS 1.2
- fail templating if TLS 1.3 is enabled along with TLS 1.1 or TLS 1.0
- integration test to check that TLS 1.3 and TLS 1.2 work
- retain integration test to check TLS 1.0, TLS 1.1 and TLS 1.2 work
- allow TLS 1.3 ciphers (these have underscores: `_` while previous cipher suites had dashes: `-`)

Integration tests:
I spent a lot of time trying to replicate the CI integration tests locally, but could not get them to work. Given the changes to the tests were not too large, I decided to push and test. These commits have now been reverted and will be added back as part of this PR. 