### PR TITLE
Cuttlefish-format fix on Update 50-overrideConfig.conf.erb

### DIFF
--- a/jobs/rabbitmq-server/templates/config-files/50-overrideConfig.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/50-overrideConfig.conf.erb
@@ -1,3 +1,5 @@
 <% if_p("rabbitmq-server.override_config") do |config| -%>
-<%= config %>
+<% config.each do |key, value| %>
+<%= key %> = <%= value %>
+<% end %>
 <% end -%>


### PR DESCRIPTION
Cuttlefish-format should be `key=value`, the old code was creating config like this: `{"key"=>"value"}`