### PR TITLE
Prom Scraper: Use DNS Address in instance id when hot swap is enabled

### DIFF
--- a/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,6 @@
 ---
 port: 15692
 source_id: <%= if p('rabbitmq-server.cluster_name') == "" then 'rabbit@localhost' else p('rabbitmq-server.cluster_name') end %>
-instance_id: rabbit@<%= Digest::MD5.hexdigest(spec.ip) %>
+instance_id: <%= if p('rabbitmq-server.create_swap_delete') == true then "'rabbit@#{spec.address}'" else "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'" end %>
 scheme: http
 server_name: localhost

--- a/spec/unit/templates/prom_scraper_config_spec.rb
+++ b/spec/unit/templates/prom_scraper_config_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+require 'bosh/template/test'
+
+RSpec.describe 'Configuration', template: true do
+  let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../../..')) }
+  let(:job) { release.job('rabbitmq-server') }
+  let(:template) { job.template('config/prom_scraper_config.yml') }
+  let(:instance) { Bosh::Template::Test::InstanceSpec.new(ip: '1.1.1.1', address: 'instance-1.example.bosh') }
+  let(:link_instances) { [] }
+  let(:link) { Bosh::Template::Test::Link.new(name: 'rabbitmq-server', instances: link_instances) }
+  let(:manifest) { { 'rabbitmq-server' => {} } }
+  let(:rendered_template) { template.render(manifest, spec: instance, consumes: [link]) }
+
+  describe 'Prom Scraper Config' do
+    it 'sets the port to the rabbitmq prometheus port' do
+      expect(rendered_template).to include('port: 15692')
+    end
+
+    it 'sets the scheme to http' do
+      expect(rendered_template).to include('scheme: http')
+    end
+
+    it 'sets server name to localhost' do
+      expect(rendered_template).to include('server_name: localhost')
+    end
+
+    context 'when cluster_name is provided' do 
+      it 'source_id includes the cluster name' do
+        manifest['rabbitmq-server']['cluster_name'] = 'ha-cluster'
+        expect(rendered_template).to include('source_id: ha-cluster')
+      end
+    end
+
+    context 'when cluster_name is not provided' do
+      it 'source_id is set to rabbit@localhost' do
+        expect(rendered_template).to include('source_id: rabbit@localhost')
+      end
+    end
+  
+    context 'when create_swap_delete is true' do
+      before(:each) do
+        manifest['rabbitmq-server']['create_swap_delete'] = true
+      end
+
+      it 'sets the instance id to the dns address' do
+        expect(rendered_template).to include("instance_id: 'rabbit@instance-1.example.bosh'\n")
+      end
+    end
+
+    context 'when create_swap_delete is false' do
+      it 'sets the instance id to the ip address' do
+        expect(rendered_template).to include("instance_id: 'rabbit@#{Digest::MD5.hexdigest('1.1.1.1')}'\n")
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Also add missing tests for the prom scraper config file.