### PR TITLE
[ci skip] Add version metadata to openssl package

### DIFF
--- a/packages/openssl/spec
+++ b/packages/openssl/spec
@@ -1,5 +1,7 @@
 ---
 name: openssl
+metadata:
+  version: 1.1.1i
 
 dependencies: []
 


### PR DESCRIPTION
This allows our tooling to bump the version when a later release comes out.