### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -20,10 +20,10 @@ golang/go1.16.3.linux-amd64.tar.gz:
   object_id: eb41ccb1-e15c-4d88-559f-8e69a9efecc8
   sha: sha256:951a3c7c6ce4e56ad883f97d9db74d3d6d80d5fec77455c6ada6c1f7ac4776d2
 # this comment prevents git conflicts
-haproxy/haproxy-1.8.29.tar.gz:
-  size: 2213262
-  object_id: 4c1bcdbd-cd33-4638-439f-5dbbbe219293
-  sha: sha256:a91777252bd655413411b832fbce7bb3a27b0484b498e2c614c405e12f53a764
+haproxy/haproxy-1.8.30.tar.gz:
+  size: 2214184
+  object_id: 7ce535fa-f17c-4c08-782f-1c24f83287a8
+  sha: sha256:066bfd9a0e5a3550fa621886a132379e5331d0c377e11f38bb6e8dfbec92be42
 # this comment prevents git conflicts
 openssl/openssl-1.1.1k.tar.gz:
   size: 9823400

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="1.8.29"
+VERSION="1.8.30"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 1.8.29
+  version: 1.8.30
 files:
-- haproxy/haproxy-1.8.29.tar.gz
+- haproxy/haproxy-1.8.30.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 1.8.30