### PR TITLE
Do not double quote escape cluster name

### DIFF
--- a/jobs/rabbitmq-server/templates/config-files/10-clusterDefaults.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/10-clusterDefaults.conf.erb
@@ -36,7 +36,7 @@ mqtt.subscription_ttl = 1800000
 
 <% if_p("rabbitmq-server.cluster_name") do |cluster_name| -%>
 <% if cluster_name != "" -%>
-cluster_name = "<%= cluster_name %>"
+cluster_name = <%= cluster_name %>
 <% end -%>
 <% end -%>
 

--- a/spec/unit/templates/10-clusterDefaults_spec.rb
+++ b/spec/unit/templates/10-clusterDefaults_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Configuration', template: true do
   context 'when there is no config provided' do
 		let(:manifest_properties) { {
 				'rabbitmq-server' => {}
-      } 
+      }
     }
     it 'renders cluster default configuration' do
       expect(rendered_template).to include('log.connection.level = info')
@@ -96,10 +96,10 @@ RSpec.describe 'Configuration', template: true do
 				'rabbitmq-server' => {
           'cluster_name': 'my-favourite-rabbit'
         }
-      } 
+      }
     }
     it 'configures the cluster name' do
-      expect(rendered_template).to include('cluster_name = "my-favourite-rabbit"')
+      expect(rendered_template).to include('cluster_name = my-favourite-rabbit')
     end
   end
 


### PR DESCRIPTION
This breaks integration with RabbitMQ Grafana dashboards. RabbitMQ can handle names with spaces without escaping.