### PR TITLE
Expose prom_scraper labels

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -137,6 +137,10 @@ properties:
     description: "If true, configure rabbitmq-server to use vm_strategy create-swap-delete (i.e. use RabbitMQ long node names, FQDNs for Rabbit nodes names, and no hosts in erl_inetrc)."
     default: false
 
+  rabbitmq-server.prom_scraper_labels:
+    description: "Optional metric labels (see loggregator-agent's prom_scraper job for details)"
+    default: {}
+
 templates:
   add-rabbitmqctl-to-path.bash:             bin/add-rabbitmqctl-to-path
   cleanup-http-logs.bash:                   bin/cleanup-http-logs

--- a/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
@@ -4,3 +4,9 @@ source_id: <%= if p('rabbitmq-server.cluster_name') == "" then 'rabbit@localhost
 instance_id: <%= if p('rabbitmq-server.create_swap_delete') == true then "'rabbit@#{spec.address}'" else "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'" end %>
 scheme: http
 server_name: localhost
+<% if_p('rabbitmq-server.prom_scraper_labels') do |labels| %>
+labels:
+  <% labels.each do |key, value| %>
+  <%= key %>: <%= value %>
+  <% end %>
+<% end %>

--- a/spec/unit/templates/prom_scraper_config_spec.rb
+++ b/spec/unit/templates/prom_scraper_config_spec.rb
@@ -24,7 +24,16 @@ RSpec.describe 'Configuration', template: true do
       expect(rendered_template).to include('server_name: localhost')
     end
 
-    context 'when cluster_name is provided' do 
+    context 'when prom_scraper labels are set' do
+      it 'adds the labels to the prom_scraper_config file' do
+        manifest['rabbitmq-server']['prom_scraper_labels'] = { 'key1' => 'value1', 'key2' => 'value2' }
+        expect(rendered_template).to include('labels:')
+        expect(rendered_template).to include('  key1: value1')
+        expect(rendered_template).to include('  key2: value2')
+      end
+    end
+
+    context 'when cluster_name is provided' do
       it 'source_id includes the cluster name' do
         manifest['rabbitmq-server']['cluster_name'] = 'ha-cluster'
         expect(rendered_template).to include('source_id: ha-cluster')
@@ -36,7 +45,7 @@ RSpec.describe 'Configuration', template: true do
         expect(rendered_template).to include('source_id: rabbit@localhost')
       end
     end
-  
+
     context 'when create_swap_delete is true' do
       before(:each) do
         manifest['rabbitmq-server']['create_swap_delete'] = true


### PR DESCRIPTION
prom_scraper (part of loggregator-agent) allows arbitrary labels to be
configured. With this change, labels can be specified when deploying
cf-rabbitmq-release.