### PR TITLE
Allow prom scraper to use https

### DIFF
--- a/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
@@ -2,7 +2,7 @@
 port: 15692
 source_id: <%= if p('rabbitmq-server.cluster_name') == "" then 'rabbit@localhost' else p('rabbitmq-server.cluster_name') end %>
 instance_id: <%= if p('rabbitmq-server.create_swap_delete') == true then "'rabbit@#{spec.address}'" else "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'" end %>
-scheme: http
+scheme: <%= if p("rabbitmq-server.management_tls.enabled") then 'https' else 'http' end %>
 server_name: localhost
 <% if_p('rabbitmq-server.prom_scraper_labels') do |labels| %>
 labels:

--- a/spec/unit/templates/prom_scraper_config_spec.rb
+++ b/spec/unit/templates/prom_scraper_config_spec.rb
@@ -16,8 +16,17 @@ RSpec.describe 'Configuration', template: true do
       expect(rendered_template).to include('port: 15692')
     end
 
-    it 'sets the scheme to http' do
-      expect(rendered_template).to include('scheme: http')
+    context 'when management has TLS enabled' do
+      it 'sets scheme to https' do
+        manifest['rabbitmq-server']['management_tls'] = { 'enabled' => true }
+        expect(rendered_template).to include('scheme: https')
+      end
+    end
+
+    context 'when management has TLS disabled' do
+      it 'sets scheme to http' do
+        expect(rendered_template).to include('scheme: http')
+      end
     end
 
     it 'sets server name to localhost' do


### PR DESCRIPTION
This prevents prom scraper from failing when prometheus is secured with TLS

