### PR TITLE
Update golang package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,27 +1,35 @@
+---
+# this comment prevents git conflicts
 basht/basht_0.1.0_Linux_x86_64.tgz:
   size: 757703
   object_id: bbc2200b-670b-4562-72db-27ce98bc3161
   sha: 5dee8d242fc333672e14d9e1d70162b77eab5924
+# this comment prevents git conflicts
 erlang-24/otp_src_oss_24.2.1.tgz:
   size: 59519393
   object_id: 1850d8bb-c116-4fc4-6525-26802774514c
   sha: sha256:ee51a40b96c9a43257c5af4c726b32b7f5cd16b2873f45532fe5fc29a34e743f
-golang/go1.17.6.linux-amd64.tar.gz:
-  size: 134830580
-  object_id: bc515bcc-4ee0-4275-77a3-fd60771aa8b5
-  sha: sha256:231654bbf2dab3d86c1619ce799e77b03d96f9b50770297c8f4dff8836fc8ca2
+# this comment prevents git conflicts
+golang/go1.17.7.linux-amd64.tar.gz:
+  size: 134835336
+  object_id: 8312c75c-9328-4fbd-47b0-2be104c5b3c8
+  sha: sha256:02b111284bedbfa35a7e5b74a06082d18632eff824fd144312f6063943d49259
+# this comment prevents git conflicts
 haproxy/haproxy-1.8.30.tar.gz:
   size: 2214184
   object_id: 7ce535fa-f17c-4c08-782f-1c24f83287a8
   sha: sha256:066bfd9a0e5a3550fa621886a132379e5331d0c377e11f38bb6e8dfbec92be42
+# this comment prevents git conflicts
 openssl/openssl-1.1.1m.tar.gz:
   size: 9847315
   object_id: bf2c05cf-246a-4286-7500-fa0659544448
   sha: sha256:f89199be8b23ca45fc7cb9f1d8d3ee67312318286ad030f5316aca6462db6c96
+# this comment prevents git conflicts
 rabbitmq-server-3.8/rabbitmq-server-generic-unix-3.8.27.tar.xz:
   size: 15713376
   object_id: 1530e7f6-95be-41fc-5c8c-fdfe30517778
   sha: sha256:55569e00710ae54ff2801c1bac18c0360e00ecceee2949744be1a3e2f362f4c8
+# this comment prevents git conflicts
 rabbitmq-server-3.9/rabbitmq-server-generic-unix-3.9.13.tar.xz:
   size: 12660820
   object_id: 66250eee-cc08-4db0-70ac-44dfdfd8b404

--- a/packages/golang/packaging
+++ b/packages/golang/packaging
@@ -1,3 +1,3 @@
 set -e
 
-tar xzf golang/go1.17.6.linux-amd64.tar.gz --strip-components=1 -C "${BOSH_INSTALL_TARGET}"
+tar xzf golang/go1.17.7.linux-amd64.tar.gz --strip-components=1 -C "${BOSH_INSTALL_TARGET}"

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -1,7 +1,7 @@
 ---
 name: golang
 metadata:
-  version: '1.17.6'
+  version: '1.17.7'
 
 files:
-  - golang/go1.17.6.linux-amd64.tar.gz
+  - golang/go1.17.7.linux-amd64.tar.gz


### PR DESCRIPTION
This PR updates the version of golang to 1.17.7