### PR TITLE
Add prom_scraper config for detailed endpoint

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -141,6 +141,10 @@ properties:
     description: "Optional metric labels (see loggregator-agent's prom_scraper job for details)"
     default: {}
 
+  rabbitmq-server.prom_scraper_detailed_endpoint_query:
+    description: "Query parameters to append to the prom_scraper target endpoint for `/metrics/detailed`, including the leading `?`. See https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_prometheus/README.md#selective-querying-of-per-object-metrics"
+    default: ""
+
   rabbitmq-server.stream.advertised_host:
     description: "Hostname returned when asked for the stream topology."
     default: ""
@@ -152,6 +156,7 @@ properties:
   rabbitmq-server.stream.advertised_tls_port:
     description: "Port returned when asked for the stream topology over TLS."
     default: ""
+
 
 templates:
   add-rabbitmqctl-to-path.bash:             bin/add-rabbitmqctl-to-path
@@ -184,6 +189,7 @@ templates:
   rabbitmq-config-vars.bash.erb:            lib/rabbitmq-config-vars.bash
   indicators.yml.erb:                       config/indicators.yml
   prom_scraper_config.yml.erb:              config/prom_scraper_config.yml
+  prom_scraper_detailed_config.yml.erb:     config/prom_scraper_detailed_config.yml
   config-files/advanced.config.erb:         etc/advanced.config
   config-files/inter_node_tls.config.erb:   etc/inter_node_tls.config
   config-files/10-clusterDefaults.conf.erb: etc/conf.d/10-clusterDefaults.conf

--- a/jobs/rabbitmq-server/templates/prom_scraper_detailed_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_detailed_config.yml.erb
@@ -2,7 +2,7 @@
 port: <%= if p("rabbitmq-server.management_tls.enabled") then 15691 else 15692 end %>
 source_id: <%= if p('rabbitmq-server.cluster_name') == "" then 'rabbit@localhost' else p('rabbitmq-server.cluster_name') end %>
 instance_id: <%= if p('rabbitmq-server.create_swap_delete') == true then "'rabbit@#{spec.address}'" else "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'" end %>
-path: /metrics
+path: /metrics/detailed<%= p('rabbitmq-server.prom_scraper_detailed_endpoint_query') %>
 scheme: <%= if p("rabbitmq-server.management_tls.enabled") then 'https' else 'http' end %>
 
 <%

--- a/spec/unit/templates/prom_scraper_config_spec.rb
+++ b/spec/unit/templates/prom_scraper_config_spec.rb
@@ -86,6 +86,42 @@ RSpec.describe 'Configuration', template: true do
       end
     end
 
+    context 'when using the aggregated metrics' do
+      it 'sets scrape path accordingly' do
+        expect(rendered_template).to include('path: /metrics')
+      end
+    end
+
+    context 'when using the per-object metrics' do
+      it 'sets scrape path accordingly' do
+        template = job.template('config/prom_scraper_per_object_config.yml')
+        rendered_template = template.render(manifest, spec: instance, consumes: [link])
+        expect(rendered_template).to include('path: /metrics/per-object')
+      end
+    end
+
+    context 'when using the detailed metrics' do
+      context 'when the custom scrape query is unset' do
+        it 'sets scrape path accordingly' do
+          template = job.template('config/prom_scraper_detailed_config.yml')
+          rendered_template = template.render(manifest, spec: instance, consumes: [link])
+          expect(rendered_template).to include('path: /metrics/detailed')
+        end
+      end
+
+      context 'when the custom scrape query is unset' do
+        before(:each) do
+          manifest['rabbitmq-server']['prom_scraper_detailed_endpoint_query'] = '?foo=bar&baz=vhost'
+        end
+
+        it 'sets scrape path accordingly' do
+          template = job.template('config/prom_scraper_detailed_config.yml')
+          rendered_template = template.render(manifest, spec: instance, consumes: [link])
+          expect(rendered_template).to include('path: /metrics/detailed?foo=bar&baz=vhost')
+        end
+      end
+    end
+
     context 'when create_swap_delete is false' do
       it 'sets the instance id to the ip address' do
         expect(rendered_template).to include("instance_id: 'rabbit@#{Digest::MD5.hexdigest('1.1.1.1')}'\n")


### PR DESCRIPTION
This allows a user to specify which family of metrics, or vhosts, to gather additional metrics for. It is expected that a colocated prom_scraper job would include the new prom_scraper config file with the [config_globs property](https://github.com/cloudfoundry/loggregator-agent-release/blob/f9906c7b2e3f160f04d109f6fc43e4934b63f940/jobs/prom_scraper/spec#L29-L31).