### PR TITLE
Add ops file to force use of IP addresses from BOSH DNS

### DIFF
--- a/manifests/use-ip-addresses.yml
+++ b/manifests/use-ip-addresses.yml
@@ -1,0 +1,6 @@
+---
+- type: replace
+  path: /instance_groups/name=rmq/jobs/name=rabbitmq-server/consumes?
+  value:
+    rabbitmq-server:
+      ip_addresses: true


### PR DESCRIPTION
We observed a failure in our pipeline of the cf-rabbitmq-release; this was due to the CF Deployment environments
we use for testing being upgraded from CF v19 to v20. This change seems to have enabled `use_dns_addresses` on the BOSH director
for these test environments, meaning that even if create_swap_delete is disabled, the server address received by this BOSH release
is a hostname rather than a resolved IP. This leads to the erl_inetrc file being mispopulated with hostnames instead of IP addresses,
leading to a failure in the pre-start script.

If deploying this release in CI, and the global property use_dns_addresses is true, this ops file will also be needed to force the BOSH link
providing the server addresses to provide them as resolved internal IPs instead of hostnames.