### PR TITLE
Prom scraper source id can be log-cache compatible

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -137,6 +137,14 @@ properties:
     description: "If true, configure rabbitmq-server to use vm_strategy create-swap-delete (i.e. use RabbitMQ long node names, FQDNs for Rabbit nodes names, and no hosts in erl_inetrc)."
     default: false
 
+  rabbitmq-server.ensure_log_cache_compatibility:
+    description: "Ensures the prom_scraper source_id is compatible with log cache"
+    default: false
+
+  rabbitmq-server.prom_scraper_source_id:
+    description: "The source ID to set on scraped metrics. Must be 48 characters or less to be compatible with log-cache. Warning: Changing this on a live deployment will cause discontinuity in metrics from that deployment."
+    default: ""
+
   rabbitmq-server.prom_scraper_labels:
     description: "Optional metric labels (see loggregator-agent's prom_scraper job for details)"
     default: {}

--- a/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
@@ -1,6 +1,19 @@
 ---
 port: <%= if p("rabbitmq-server.management_tls.enabled") then 15691 else 15692 end %>
-source_id: <%= if p('rabbitmq-server.cluster_name') == "" then 'rabbit@localhost' else p('rabbitmq-server.cluster_name') end %>
+
+<%
+if p('rabbitmq-server.prom_scraper_source_id') != "" then
+  source_id = p('rabbitmq-server.prom_scraper_source_id')
+  if p('rabbitmq-server.ensure_log_cache_compatibility') and p('rabbitmq-server.prom_scraper_source_id').length > 48 then
+    raise 'prom_scraper source_id must be 48 characters or less'
+  end
+elsif p('rabbitmq-server.cluster_name') == "" then
+  source_id = 'rabbit@localhost'
+else
+ source_id = p('rabbitmq-server.cluster_name')
+end
+-%>
+source_id: <%= source_id %>
 instance_id: <%= if p('rabbitmq-server.create_swap_delete') == true then "'rabbit@#{spec.address}'" else "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'" end %>
 path: /metrics
 scheme: <%= if p("rabbitmq-server.management_tls.enabled") then 'https' else 'http' end %>

--- a/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
@@ -2,19 +2,30 @@
 port: <%= if p("rabbitmq-server.management_tls.enabled") then 15691 else 15692 end %>
 
 <%
-if p('rabbitmq-server.prom_scraper_source_id') != "" then
-  source_id = p('rabbitmq-server.prom_scraper_source_id')
-  if p('rabbitmq-server.ensure_log_cache_compatibility') and p('rabbitmq-server.prom_scraper_source_id').length > 48 then
-    raise 'prom_scraper source_id must be 48 characters or less'
+  if p('rabbitmq-server.prom_scraper_source_id') != "" then
+    source_id = p('rabbitmq-server.prom_scraper_source_id')
+    if p('rabbitmq-server.ensure_log_cache_compatibility') and p('rabbitmq-server.prom_scraper_source_id').length > 48 then
+      raise 'prom_scraper source_id must be 48 characters or less'
+    end
+  elsif p('rabbitmq-server.cluster_name') == "" then
+    source_id = 'rabbit@localhost'
+  else
+   source_id = p('rabbitmq-server.cluster_name')
   end
-elsif p('rabbitmq-server.cluster_name') == "" then
-  source_id = 'rabbit@localhost'
-else
- source_id = p('rabbitmq-server.cluster_name')
-end
 -%>
 source_id: <%= source_id %>
-instance_id: <%= if p('rabbitmq-server.create_swap_delete') == true then "'rabbit@#{spec.address}'" else "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'" end %>
+
+<%
+  if p('rabbitmq-server.create_swap_delete') == true then
+    instance_id = "'rabbit@#{spec.address}'"
+  else
+    instance_id = "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'"
+  end
+if p('rabbitmq-server.ensure_log_cache_compatibility') == true then
+  instance_id = spec.id || spec.index.to_s
+end
+-%>
+instance_id: <%= instance_id %>
 path: /metrics
 scheme: <%= if p("rabbitmq-server.management_tls.enabled") then 'https' else 'http' end %>
 

--- a/jobs/rabbitmq-server/templates/prom_scraper_detailed_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_detailed_config.yml.erb
@@ -14,7 +14,17 @@ else
 end
 -%>
 source_id: <%= source_id %>
-instance_id: <%= if p('rabbitmq-server.create_swap_delete') == true then "'rabbit@#{spec.address}'" else "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'" end %>
+<%
+  if p('rabbitmq-server.create_swap_delete') == true then
+    instance_id = "'rabbit@#{spec.address}'"
+  else
+    instance_id = "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'"
+  end
+if p('rabbitmq-server.ensure_log_cache_compatibility') == true then
+  instance_id = spec.id || spec.index.to_s
+end
+-%>
+instance_id: <%= instance_id %>
 path: /metrics/detailed<%= p('rabbitmq-server.prom_scraper_detailed_endpoint_query') %>
 scheme: <%= if p("rabbitmq-server.management_tls.enabled") then 'https' else 'http' end %>
 

--- a/jobs/rabbitmq-server/templates/prom_scraper_detailed_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_detailed_config.yml.erb
@@ -1,6 +1,19 @@
 ---
 port: <%= if p("rabbitmq-server.management_tls.enabled") then 15691 else 15692 end %>
-source_id: <%= if p('rabbitmq-server.cluster_name') == "" then 'rabbit@localhost' else p('rabbitmq-server.cluster_name') end %>
+
+<%
+if p('rabbitmq-server.prom_scraper_source_id') != "" then
+  source_id = p('rabbitmq-server.prom_scraper_source_id')
+  if p('rabbitmq-server.ensure_log_cache_compatibility') and p('rabbitmq-server.prom_scraper_source_id').length > 48 then
+    raise 'prom_scraper source_id must be 48 characters or less'
+  end
+elsif p('rabbitmq-server.cluster_name') == "" then
+  source_id = 'rabbit@localhost'
+else
+ source_id = p('rabbitmq-server.cluster_name')
+end
+-%>
+source_id: <%= source_id %>
 instance_id: <%= if p('rabbitmq-server.create_swap_delete') == true then "'rabbit@#{spec.address}'" else "'rabbit@#{Digest::MD5.hexdigest(spec.ip)}'" end %>
 path: /metrics/detailed<%= p('rabbitmq-server.prom_scraper_detailed_endpoint_query') %>
 scheme: <%= if p("rabbitmq-server.management_tls.enabled") then 'https' else 'http' end %>

--- a/spec/unit/templates/prom_scraper_config_spec.rb
+++ b/spec/unit/templates/prom_scraper_config_spec.rb
@@ -57,6 +57,21 @@ RSpec.describe 'Configuration', template: true do
       end
     end
 
+    context 'when source_id is explicitly provided' do
+      it 'sets the source_id without modification' do
+        manifest['rabbitmq-server']['prom_scraper_source_id'] = 'prom_scraper_source_id'
+        expect(rendered_template).to include('source_id: prom_scraper_source_id')
+      end
+    end
+
+    context 'when ensure_log_cache_compatibility is  provided' do
+      it 'errors if source_id is greater than 48 characters in length' do
+        manifest['rabbitmq-server']['prom_scraper_source_id'] = 'source_id_longer_than_48_characters---------------'
+        manifest['rabbitmq-server']['ensure_log_cache_compatibility'] = true
+        expect{ rendered_template }.to raise_error 'prom_scraper source_id must be 48 characters or less'
+      end
+    end
+
     context 'when cluster_name is provided' do
       it 'source_id includes the cluster name' do
         manifest['rabbitmq-server']['cluster_name'] = 'ha-cluster'

--- a/spec/unit/templates/prom_scraper_config_spec.rb
+++ b/spec/unit/templates/prom_scraper_config_spec.rb
@@ -70,6 +70,13 @@ RSpec.describe 'Configuration', template: true do
         manifest['rabbitmq-server']['ensure_log_cache_compatibility'] = true
         expect{ rendered_template }.to raise_error 'prom_scraper source_id must be 48 characters or less'
       end
+
+      it 'sets the instance_id to the vm index' do
+        manifest['rabbitmq-server']['prom_scraper_source_id'] = 'source_id_and_vm_index'
+        manifest['rabbitmq-server']['ensure_log_cache_compatibility'] = true
+        expect(rendered_template).to include('instance_id: xxxxxx-xxxxxxxx-xxxxx')
+        expect(rendered_template).to_not include('instance_id: rabbit@')
+      end
     end
 
     context 'when cluster_name is provided' do


### PR DESCRIPTION
This is the first PR to address this issue https://github.com/rabbitmq/service-operator-experience/issues/47

Raise a templating error when attempting to set source id with greater than 48 characters.