### PR TITLE
Keep logging to a file for RabbitMQ >= 3.9

### DIFF
--- a/jobs/rabbitmq-server/templates/config-files/10-clusterDefaults.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/10-clusterDefaults.conf.erb
@@ -44,3 +44,5 @@ cluster_name = <%= cluster_name %>
 load_definitions = /var/vcap/jobs/rabbitmq-server/etc/definitions.json
 <% end -%>
 
+log.dir = /var/vcap/sys/log/rabbitmq-server
+log.file.level = info


### PR DESCRIPTION
If `log.exchange = true` is set,
in RabbitMQ 3.8 logs were also written to a file, vs.
in RabbitMQ 3.9 logs are not written to a file anymore.

Until RabbitMQ 3.8 logs were always written to a file (unless
`log.file = false` is set).
From RabbitMQ 3.9 onwards logs are written to a file by default, but not if
other log outputs (e.g. `log.exchange`) are configured.

To maintain backwards compatiblity in the cf-rabbitmq-release, for users
upgrading from RabbitMQ 3.8 to 3.9 (or later), we explicitly set
`log.file.level = info` which ensures a log file gets written as before
independent of for example `log.exchange` being configured.

(The user should still be able to override `log.file.level`
via the override config.)