### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,10 +15,10 @@ golang/go1.19.linux-amd64.tar.gz:
   object_id: 803a7168-5d6c-46cb-67e4-b80a2d3a38f4
   sha: sha256:464b6b66591f6cf055bc5df90a9750bf5fbc9d038722bb84a9d56a2bea974be6
 # this comment prevents git conflicts
-haproxy/haproxy-2.6.4.tar.gz:
-  size: 3986583
-  object_id: f499ddd4-4620-41ee-565e-a4883eb7d595
-  sha: sha256:f07d67ada2ff3a999fed4e34459c0489536331a549665ac90cb6a8df91f4a289
+haproxy/haproxy-2.6.5.tar.gz:
+  size: 4010014
+  object_id: e8c184ec-5012-45f5-65a2-2a161a7b004b
+  sha: sha256:ce9e19ebfcdd43e51af8a6090f1df8d512d972ddf742fa648a643bbb19056605
 # this comment prevents git conflicts
 openssl/openssl-1.1.1q.tar.gz:
   size: 9864061

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="2.6.4"
+VERSION="2.6.5"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 2.6.4
+  version: 2.6.5
 files:
-- haproxy/haproxy-2.6.4.tar.gz
+- haproxy/haproxy-2.6.5.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 2.6.5