### PR TITLE
Add Erlang 25

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,40 +1,35 @@
----
-# this comment prevents git conflicts
 basht/basht_0.1.0_Linux_x86_64.tgz:
   size: 757703
   object_id: bbc2200b-670b-4562-72db-27ce98bc3161
   sha: 5dee8d242fc333672e14d9e1d70162b77eab5924
-# this comment prevents git conflicts
 erlang-24/otp_src_oss_24.3.4.5.tgz:
   size: 60010786
   object_id: fdcea696-06f2-4f0a-4ea9-aaeaa033b2d0
   sha: sha256:1ff9bce02891352da5e1ba78b263cb5f465900342d9c72690b97905bf405b48b
-# this comment prevents git conflicts
+erlang-25/otp_src_25.1.tgz:
+  size: 103454812
+  object_id: a961e144-48cc-40ee-64f2-e6c9c363a7ce
+  sha: sha256:a5ea27c1e07511a84bdd869c37f5e254f198c1cecf68ee9c8fedd23010750c31
 golang/go1.19.1.linux-amd64.tar.gz:
   size: 148820241
   object_id: 734fe109-aace-4325-5fbb-346932a93436
   sha: sha256:acc512fbab4f716a8f97a8b3fbaa9ddd39606a28be6c2515ef7c6c6311acffde
-# this comment prevents git conflicts
 haproxy/haproxy-2.6.6.tar.gz:
   size: 4015438
   object_id: 8b650d8e-9e67-4250-54b9-9b8c388edc8a
   sha: sha256:d0c80c90c04ae79598b58b9749d53787f00f7b515175e7d8203f2796e6a6594d
-# this comment prevents git conflicts
 openssl/openssl-1.1.1q.tar.gz:
   size: 9864061
   object_id: f6b64f54-3a96-46e0-6488-4ffb05fbc50f
   sha: sha256:d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca
-# this comment prevents git conflicts
 rabbitmq-server-3.8/rabbitmq-server-generic-unix-3.8.35.tar.xz:
   size: 15825620
   object_id: 7442d589-7af9-4353-5737-e396ad7551ed
   sha: sha256:09c970742b84209af5fe7e8f38ad8eaa9d074b798056bbe7dc83a7a32df3d9af
-# this comment prevents git conflicts
 rabbitmq-server-3.9/rabbitmq-server-generic-unix-3.9.22.tar.xz:
   size: 12761888
   object_id: 653d2b7d-0975-4eb6-762e-eeafaa3dc4d6
   sha: sha256:acf2fa033226ba389333562ec1684dfcc18a53bdf06162f29d3898c85b730be6
-# this comment prevents git conflicts
 rabbitmq-server-3.10/rabbitmq-server-generic-unix-3.10.7.tar.xz:
   size: 12818592
   object_id: 94246749-4b1b-49fd-48f4-4d36ee46121c

--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -88,7 +88,7 @@ properties:
 
   rabbitmq-server.erlang_major_version:
     description: "Major version of Erlang to use on RabbitMQ instances in this deployment"
-    default: 24
+    default: 24 # We should not change the deafult until 31st October 2022, when Tile 2.0 is EOGS.
   rabbitmq-server.cookie:
     description: "Erlang cookie used by RabbitMQ nodes and rabbitmqctl. You should set this to a secure password"
 

--- a/packages/erlang-25/packaging
+++ b/packages/erlang-25/packaging
@@ -1,0 +1,51 @@
+set -e
+
+export HOME=${BOSH_INSTALL_DIR}
+
+cpus="$(grep -c ^processor /proc/cpuinfo)"
+
+VERSION="25.1"
+MAJOR_VERSION="25"
+echo "$MAJOR_VERSION" > "$BOSH_INSTALL_TARGET/erlang_version"
+
+tar xzf erlang-25/otp_src_oss_${VERSION}.tgz
+cd otp_src_oss_${VERSION}
+./configure \
+  --with-ssl="/var/vcap/packages/openssl/external/openssl/" \
+  --with-ssl-rpath="/var/vcap/packages/openssl/external/openssl/lib/" \
+	--disable-hipe \
+	--disable-sctp \
+	--disable-silent-rules \
+	--enable-dynamic-ssl-lib \
+	--enable-clock-gettime \
+	--enable-dynamic-ssl \
+	--enable-hybrid-heap \
+	--enable-kernel-poll \
+	--enable-shared-zlib \
+	--enable-smp-support \
+	--enable-threads \
+	--enable-lock-counter \
+	--with-microstate-accounting=extra \
+	--without-common_test \
+	--without-debugger \
+	--without-dialyzer \
+	--without-diameter \
+	--without-edoc \
+	--without-erl_docgen \
+	--without-et \
+	--without-eunit \
+	--without-ftp \
+	--without-hipe \
+	--without-jinterface \
+	--without-megaco \
+	--without-observer \
+	--without-odbc \
+	--without-reltool \
+	--without-ssh \
+	--without-tftp \
+	--without-wx \
+  --prefix=${BOSH_INSTALL_TARGET}
+
+make -j$cpus
+make install
+

--- a/packages/erlang-25/spec
+++ b/packages/erlang-25/spec
@@ -1,0 +1,8 @@
+---
+name: erlang-25
+metadata:
+  version: 25.1
+files:
+- erlang-25/otp_src_oss_25.1.tgz
+dependencies:
+- openssl


### PR DESCRIPTION
- Packaging script as per Erlang 24.
- Uploaded blob to blobstore

I left the rabbitmq-server Erlang version default to 24. We can update this after the 2.0 series of the tile is EOGS on 31st October 2022.