### PR TITLE
Update rabbitmq-server-3.11 package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,44 +1,53 @@
 ---
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 basht/basht_0.1.0_Linux_x86_64.tgz:
   size: 757703
   object_id: bbc2200b-670b-4562-72db-27ce98bc3161
   sha: 5dee8d242fc333672e14d9e1d70162b77eab5924
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 erlang-24/otp_src_oss_24.3.4.6.tgz:
   size: 60006884
   object_id: 9525829d-69f3-4069-4647-6ba33dd2ffb8
   sha: sha256:684a9a18e4e5bac172b639b4ba71c321774cfc16d9416a3a416bdf0a1ed23532
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 golang/go1.19.2.linux-amd64.tar.gz:
   size: 148883574
   object_id: 96f7b37a-0c12-4548-6b81-450b907823e1
   sha: sha256:5e8c5a74fe6470dd7e055a461acda8bb4050ead8c2df70f227e3ff7d8eb7eeb6
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 haproxy/haproxy-2.6.6.tar.gz:
   size: 4015438
   object_id: 8b650d8e-9e67-4250-54b9-9b8c388edc8a
   sha: sha256:d0c80c90c04ae79598b58b9749d53787f00f7b515175e7d8203f2796e6a6594d
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 openssl/openssl-1.1.1r.tar.gz:
   size: 9868506
   object_id: 95a2ccc3-b89f-4f4a-7b57-e4214b5703a6
   sha: sha256:e389352ae3d5ae4d38597bf8a54f1dcb6fb3c8b50f4fe58a94bb1bf7f85d82a0
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 rabbitmq-server-3.8/rabbitmq-server-generic-unix-3.8.35.tar.xz:
   size: 15825620
   object_id: 7442d589-7af9-4353-5737-e396ad7551ed
   sha: sha256:09c970742b84209af5fe7e8f38ad8eaa9d074b798056bbe7dc83a7a32df3d9af
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 rabbitmq-server-3.9/rabbitmq-server-generic-unix-3.9.23.tar.xz:
   size: 14768164
   object_id: 0bf66f7d-69df-4ecd-41e8-9071f9925319
   sha: sha256:e6c73f6717888c54fb1962e0d187ac1edd583d6e038634df5d87f524ce9d418d
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 rabbitmq-server-3.10/rabbitmq-server-generic-unix-3.10.8.tar.xz:
   size: 14866124
   object_id: 0257f169-bc3e-415e-7170-7f9685d6351b
   sha: sha256:37865e684f005986b060a8fed6b44eae9e14b03e6016e7392f5f42c9d622fa93
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 rabbitmq-server-3.11/rabbitmq-server-generic-unix-3.11.0.tar.xz:
   size: 15263416


### PR DESCRIPTION
This PR updates the version of rabbitmq-server-3.11 to 3.11.1