### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -20,10 +20,10 @@ golang/go1.19.3.linux-amd64.tar.gz:
   object_id: 598fbda1-6d6c-4f1e-4b4c-735ae0b0eb29
   sha: sha256:74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 # this comment prevents git conflicts
-haproxy/haproxy-2.6.6.tar.gz:
-  size: 4015438
-  object_id: 8b650d8e-9e67-4250-54b9-9b8c388edc8a
-  sha: sha256:d0c80c90c04ae79598b58b9749d53787f00f7b515175e7d8203f2796e6a6594d
+haproxy/haproxy-2.6.7.tar.gz:
+  size: 4028355
+  object_id: 9b152d3f-f64a-461b-4aa4-5030ef5326ad
+  sha: sha256:cff9b8b18a52bfec277f9c1887fac93c18e1b9f3eff48892255a7c6e64528b7d
 # this comment prevents git conflicts
 openssl/openssl-1.1.1s.tar.gz:
   size: 9868981

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="2.6.6"
+VERSION="2.6.7"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 2.6.6
+  version: 2.6.7
 files:
-- haproxy/haproxy-2.6.6.tar.gz
+- haproxy/haproxy-2.6.7.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 2.6.7