### PR TITLE
Update rabbitmq-server-3.11 package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -44,8 +44,3 @@ rabbitmq-server-3.10/rabbitmq-server-generic-unix-3.10.12.tar.xz:
   size: 14880764
   object_id: 1937c67b-66a0-4b9f-47c9-12563ab0c5df
   sha: sha256:d75e6f293a2fd33ca39722462923e0b4757eed8f5cc5333f0b3edf01145a53ce
-# this comment prevents git conflicts
-rabbitmq-server-3.11/rabbitmq-server-generic-unix-3.11.5.tar.xz:
-  size: 15309672
-  object_id: 6d07de27-279c-41c7-6048-e3a4b1fcd354
-  sha: sha256:80dcc10c7cf7dac216f44f0ee0b14d1e6195561b6360a0cc1c67decb95f4e45a


### PR DESCRIPTION
This PR updates the version of rabbitmq-server-3.11 to 3.11.5