### PR TITLE
Update rabbitmq-server-3.11 package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,49 +1,59 @@
 ---
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 basht/basht_0.1.0_Linux_x86_64.tgz:
   size: 757703
   object_id: bbc2200b-670b-4562-72db-27ce98bc3161
   sha: 5dee8d242fc333672e14d9e1d70162b77eab5924
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 erlang-24/otp_src_oss_24.3.4.7.tgz:
   size: 59989534
   object_id: cde4b4e2-815f-4a67-4f64-5d8c199d9dd3
   sha: sha256:8983bd54f7b7aec3f6d856aca8a77e7e725ac71d11540f40f9c04c30c2f79819
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 erlang-25/otp_src_oss_25.2.tgz:
   size: 60456616
   object_id: 181b8642-a12c-4c4a-7a75-046da4d66812
   sha: sha256:277748625305fda339e215a7b72140f69945b57149e1d8ba337fbc34b0b4b294
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 golang/go1.19.4.linux-amd64.tar.gz:
   size: 148931745
   object_id: 367db67f-efcf-43d9-43a4-77a9b7dfa322
   sha: sha256:c9c08f783325c4cf840a94333159cc937f05f75d36a8b307951d5bd959cf2ab8
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 haproxy/haproxy-2.6.7.tar.gz:
   size: 4028355
   object_id: 9b152d3f-f64a-461b-4aa4-5030ef5326ad
   sha: sha256:cff9b8b18a52bfec277f9c1887fac93c18e1b9f3eff48892255a7c6e64528b7d
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 openssl/openssl-1.1.1s.tar.gz:
   size: 9868981
   object_id: cb0b36e0-f99e-4f26-405a-afa944d30a02
   sha: sha256:c5ac01e760ee6ff0dab61d6b2bbd30146724d063eb322180c6f18a6f74e4b6aa
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 rabbitmq-server-3.8/rabbitmq-server-generic-unix-3.8.35.tar.xz:
   size: 15825620
   object_id: 7442d589-7af9-4353-5737-e396ad7551ed
   sha: sha256:09c970742b84209af5fe7e8f38ad8eaa9d074b798056bbe7dc83a7a32df3d9af
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 rabbitmq-server-3.9/rabbitmq-server-generic-unix-3.9.27.tar.xz:
   size: 14779428
   object_id: 68c7dfb5-9553-4036-4bcb-307ad2b91ae2
   sha: sha256:dc6ff9f39e3d335d6705305d7442d24da278cfc573dc313e896518749a636396
 # this comment prevents git conflicts
+# this comment prevents git conflicts
 rabbitmq-server-3.10/rabbitmq-server-generic-unix-3.10.13.tar.xz:
   size: 14893804
   object_id: bb44ec82-7b58-4603-53ec-99367632b34b
   sha: sha256:85c636a6b0d30196f26ab4bcaa79e2455afc4847d564bf1433a2beefcf24d836
+# this comment prevents git conflicts
 # this comment prevents git conflicts
 rabbitmq-server-3.11/rabbitmq-server-generic-unix-3.11.5.tar.xz:
   size: 15309672


### PR DESCRIPTION
This PR updates the version of rabbitmq-server-3.11 to 3.11.6