### PR TITLE
Configure Client secret for Oauth 

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -125,6 +125,8 @@ properties:
     description: "The ID of the JWT signing key to be used when signing tokens."
   rabbitmq-server.oauth.client_id:
     description: "The OAuth client which presents a valid access_token acquired from an OAuth server as the password in order to authenticate with RabbitMQ."
+  rabbitmq-server.oauth.client_secret:
+    description: "The OAuth client secret"
   rabbitmq-server.oauth.provider_url:
     description: "URL of the OAuth2 provider (e.g. http://localhost:8080/uaa)"
   rabbitmq-server.oauth.uaa_client_id:

--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -123,10 +123,14 @@ properties:
     description: "The public key (verification key) of the RSA key pair used by UAA to sign the JWT token."
   rabbitmq-server.oauth.signing_key_id:
     description: "The ID of the JWT signing key to be used when signing tokens."
+  rabbitmq-server.oauth.client_id:
+    description: "The OAuth client which presents a valid access_token acquired from an OAuth server as the password in order to authenticate with RabbitMQ."
+  rabbitmq-server.oauth.provider_url:
+    description: "URL of the OAuth2 provider (e.g. http://localhost:8080/uaa)"
   rabbitmq-server.oauth.uaa_client_id:
-    description: "The UAA client which presents a valid access_token acquired from UAA as the password in order to authenticate with RabbitMQ."
+    description: "Deprecated. Do not use this property. Use rabbitmq-server.oauth.client_id instead."
   rabbitmq-server.oauth.uaa_location:
-    description: "UAA URL (e.g. http://localhost:8080/uaa)"
+    description: "Deprecated. Do not use this property. Use rabbitmq-server.oauth.provider_url instead."
 
   rabbitmq-server.check_queue_sync:
     description: "If true, waits for quorum and mirror queues to sync before stopping the node"

--- a/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
@@ -4,7 +4,6 @@ auth_backends.2 = rabbit_auth_backend_internal
 management.oauth_enabled = true
 management.oauth_client_id = <%= p('rabbitmq-server.oauth.client_id') %>
 management.oauth_client_secret = <%= p('rabbitmq-server.oauth.client_secret') %>
-management.enable_uaa = true
 management.oauth_provider_url = <%= p('rabbitmq-server.oauth.provider_url') %>
 auth_oauth2.resource_server_id = <%= p('rabbitmq-server.oauth.resource_server_id') %>
 auth_oauth2.default_key = <%= p('rabbitmq-server.oauth.signing_key_id') %>

--- a/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
@@ -3,6 +3,8 @@ auth_backends.1 = rabbit_auth_backend_oauth2
 auth_backends.2 = rabbit_auth_backend_internal
 management.oauth_enabled = true
 management.oauth_client_id = <%= p('rabbitmq-server.oauth.client_id') %>
+management.oauth_client_secret = <%= p('rabbitmq-server.oauth.client_secret') %>
+management.enable_uaa = true
 management.oauth_provider_url = <%= p('rabbitmq-server.oauth.provider_url') %>
 auth_oauth2.resource_server_id = <%= p('rabbitmq-server.oauth.resource_server_id') %>
 auth_oauth2.default_key = <%= p('rabbitmq-server.oauth.signing_key_id') %>

--- a/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
@@ -5,6 +5,7 @@ management.oauth_enabled = true
 management.oauth_client_id = <%= p('rabbitmq-server.oauth.client_id') %>
 management.oauth_client_secret = <%= p('rabbitmq-server.oauth.client_secret') %>
 management.oauth_provider_url = <%= p('rabbitmq-server.oauth.provider_url') %>
+management.oauth_scopes = openid <%= p('rabbitmq-server.oauth.resource_server_id') %>.*
 auth_oauth2.resource_server_id = <%= p('rabbitmq-server.oauth.resource_server_id') %>
 auth_oauth2.default_key = <%= p('rabbitmq-server.oauth.signing_key_id') %>
 auth_oauth2.signing_keys.<%= p('rabbitmq-server.oauth.signing_key_id') %> = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem

--- a/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
@@ -1,20 +1,13 @@
 <% if p('rabbitmq-server.oauth.enabled') -%>
 auth_backends.1 = rabbit_auth_backend_oauth2
 auth_backends.2 = rabbit_auth_backend_internal
-  <% if p('rabbitmq-server.version') <= '3.10' -%>
-management.enable_uaa = true
-management.uaa_client_id = <%= p('rabbitmq-server.oauth.uaa_client_id') %>
-management.uaa_location = <%= p('rabbitmq-server.oauth.uaa_location') %>
-  <% end -%>
-  <% if p('rabbitmq-server.version') >= '3.11' -%>
 management.oauth_enabled = true
 management.oauth_client_id = <%= p('rabbitmq-server.oauth.client_id') %>
 management.oauth_client_secret = <%= p('rabbitmq-server.oauth.client_secret') %>
 management.oauth_provider_url = <%= p('rabbitmq-server.oauth.provider_url') %>
 management.oauth_scopes = openid <%= p('rabbitmq-server.oauth.resource_server_id') %>.*
-auth_oauth2.preferred_username_claims = user_name
-  <% end -%>
 auth_oauth2.resource_server_id = <%= p('rabbitmq-server.oauth.resource_server_id') %>
+auth_oauth2.preferred_username_claims = user_name
 auth_oauth2.default_key = <%= p('rabbitmq-server.oauth.signing_key_id') %>
 auth_oauth2.signing_keys.<%= p('rabbitmq-server.oauth.signing_key_id') %> = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem
 <% end -%>

--- a/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
@@ -1,9 +1,9 @@
 <% if p('rabbitmq-server.oauth.enabled') -%>
 auth_backends.1 = rabbit_auth_backend_oauth2
 auth_backends.2 = rabbit_auth_backend_internal
-management.enable_uaa = true
-management.uaa_client_id = <%= p('rabbitmq-server.oauth.uaa_client_id') %>
-management.uaa_location = <%= p('rabbitmq-server.oauth.uaa_location') %>
+management.oauth_enabled = true
+management.oauth_client_id = <%= p('rabbitmq-server.oauth.client_id') %>
+management.oauth_provider_url = <%= p('rabbitmq-server.oauth.provider_url') %>
 auth_oauth2.resource_server_id = <%= p('rabbitmq-server.oauth.resource_server_id') %>
 auth_oauth2.default_key = <%= p('rabbitmq-server.oauth.signing_key_id') %>
 auth_oauth2.signing_keys.<%= p('rabbitmq-server.oauth.signing_key_id') %> = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem

--- a/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
@@ -7,6 +7,7 @@ management.oauth_client_secret = <%= p('rabbitmq-server.oauth.client_secret') %>
 management.oauth_provider_url = <%= p('rabbitmq-server.oauth.provider_url') %>
 management.oauth_scopes = openid <%= p('rabbitmq-server.oauth.resource_server_id') %>.*
 auth_oauth2.resource_server_id = <%= p('rabbitmq-server.oauth.resource_server_id') %>
+auth_oauth2.preferred_username_claims = user_name
 auth_oauth2.default_key = <%= p('rabbitmq-server.oauth.signing_key_id') %>
 auth_oauth2.signing_keys.<%= p('rabbitmq-server.oauth.signing_key_id') %> = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem
 <% end -%>

--- a/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
+++ b/jobs/rabbitmq-server/templates/config-files/13-oAuth.conf.erb
@@ -1,13 +1,20 @@
 <% if p('rabbitmq-server.oauth.enabled') -%>
 auth_backends.1 = rabbit_auth_backend_oauth2
 auth_backends.2 = rabbit_auth_backend_internal
+  <% if p('rabbitmq-server.version') <= '3.10' -%>
+management.enable_uaa = true
+management.uaa_client_id = <%= p('rabbitmq-server.oauth.uaa_client_id') %>
+management.uaa_location = <%= p('rabbitmq-server.oauth.uaa_location') %>
+  <% end -%>
+  <% if p('rabbitmq-server.version') >= '3.11' -%>
 management.oauth_enabled = true
 management.oauth_client_id = <%= p('rabbitmq-server.oauth.client_id') %>
 management.oauth_client_secret = <%= p('rabbitmq-server.oauth.client_secret') %>
 management.oauth_provider_url = <%= p('rabbitmq-server.oauth.provider_url') %>
 management.oauth_scopes = openid <%= p('rabbitmq-server.oauth.resource_server_id') %>.*
-auth_oauth2.resource_server_id = <%= p('rabbitmq-server.oauth.resource_server_id') %>
 auth_oauth2.preferred_username_claims = user_name
+  <% end -%>
+auth_oauth2.resource_server_id = <%= p('rabbitmq-server.oauth.resource_server_id') %>
 auth_oauth2.default_key = <%= p('rabbitmq-server.oauth.signing_key_id') %>
 auth_oauth2.signing_keys.<%= p('rabbitmq-server.oauth.signing_key_id') %> = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem
 <% end -%>

--- a/spec/unit/templates/13-oAuth_spec.rb
+++ b/spec/unit/templates/13-oAuth_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe 'Configuration', template: true do
             'enabled':true,
             'resource_server_id': '5507278f-73bc-44fd-904d-03aea4add4f0',
             'client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
+            'client_secret': 'secret',
             'provider_url': 'https://uaa.cf.example.com',
+            'oauth_scopes': 'scopes',
             'signing_key_id': 'fake-key-id',
             'signing_key': "-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
@@ -36,8 +38,9 @@ VwIDAQAB
       expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
       expect(rendered_template).to include('management.oauth_enabled = true')
       expect(rendered_template).to include('management.oauth_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
-      expect(rendered_template).to include('management.oauth_client_secret = _')
+      expect(rendered_template).to include('management.oauth_client_secret = secret')
       expect(rendered_template).to include('management.oauth_provider_url = https://uaa.cf.example.com')
+      expect(rendered_template).to include('management.oauth_scopes = openid 5507278f-73bc-44fd-904d-03aea4add4f0.*')
       expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
       expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
       expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')

--- a/spec/unit/templates/13-oAuth_spec.rb
+++ b/spec/unit/templates/13-oAuth_spec.rb
@@ -10,102 +10,51 @@ RSpec.describe 'Configuration', template: true do
   }
 
   context 'when oauth is enabled' do
-    context 'when rabbitmq_server.version is 3.10' do
-      let(:manifest_properties) { {
-          'rabbitmq-server' => {
-            'version' => '3.10',
-            'oauth' => {
-              'enabled':true,
-              'resource_server_id': '5507278f-73bc-44fd-904d-03aea4add4f0',
-              'uaa_client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
-              'uaa_location': 'https://uaa.cf.example.com',
-              'signing_key_id': 'fake-key-id',
-              'signing_key': "-----BEGIN PUBLIC KEY-----
-  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
-  6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
-  IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
-  B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
-  2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
-  QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
-  VwIDAQAB
-  -----END PUBLIC KEY-----",
-            }
+		let(:manifest_properties) { {
+				'rabbitmq-server' => {
+          'oauth' => {
+            'enabled':true,
+            'resource_server_id': '5507278f-73bc-44fd-904d-03aea4add4f0',
+            'client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
+            'client_secret': 'secret',
+            'provider_url': 'https://uaa.cf.example.com',
+            'oauth_scopes': 'scopes',
+            'signing_key_id': 'fake-key-id',
+            'signing_key': "-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
+6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
+IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
+B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
+2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
+QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
+VwIDAQAB
+-----END PUBLIC KEY-----"
           }
-        }
-      }
+		    }
+      } 
+    }
+    it 'renders the oAuth config in Cuttlefish format' do
+      expect(rendered_template).to include('auth_backends.1 = rabbit_auth_backend_oauth2')
+      expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
+      expect(rendered_template).to include('management.oauth_enabled = true')
+      expect(rendered_template).to include('management.oauth_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
+      expect(rendered_template).to include('management.oauth_client_secret = secret')
+      expect(rendered_template).to include('management.oauth_provider_url = https://uaa.cf.example.com')
+      expect(rendered_template).to include('management.oauth_scopes = openid 5507278f-73bc-44fd-904d-03aea4add4f0.*')
+      expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
+      expect(rendered_template).to include('auth_oauth2.preferred_username_claims = user_name')
+      expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
+      expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')
 
-      it 'renders the oAuth config in Cuttlefish format' do
-        expect(rendered_template).to include('auth_backends.1 = rabbit_auth_backend_oauth2')
-        expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
-        expect(rendered_template).to include('management.enable_uaa = true')
-        expect(rendered_template).to include('management.uaa_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
-        expect(rendered_template).to include('management.uaa_location = https://uaa.cf.example.com')
-        expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
-        expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
-        expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')
-
-        expect(rendered_signing_key).to include('-----BEGIN PUBLIC KEY-----
-  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
-  6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
-  IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
-  B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
-  2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
-  QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
-  VwIDAQAB
-  -----END PUBLIC KEY-----')
-      end
-    end
-
-    context 'when rabbitmq_server.version is 3.11 or greater' do
-
-      let(:manifest_properties) { {
-          'rabbitmq-server' => {
-            'version' => '3.11',
-            'oauth' => {
-              'enabled': true,
-              'resource_server_id': '5507278f-73bc-44fd-904d-03aea4add4f0',
-              'client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
-              'client_secret': 'secret',
-              'provider_url': 'https://uaa.cf.example.com',
-              'oauth_scopes': 'scopes',
-              'signing_key_id': 'fake-key-id',
-              'signing_key': "-----BEGIN PUBLIC KEY-----
-  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
-  6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
-  IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
-  B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
-  2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
-  QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
-  VwIDAQAB
-  -----END PUBLIC KEY-----",
-            }
-          }
-        }
-      }
-
-      it 'renders the oAuth config in Cuttlefish format' do
-        expect(rendered_template).to include('auth_backends.1 = rabbit_auth_backend_oauth2')
-        expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
-        expect(rendered_template).to include('management.oauth_enabled = true')
-        expect(rendered_template).to include('management.oauth_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
-        expect(rendered_template).to include('management.oauth_client_secret = secret')
-        expect(rendered_template).to include('management.oauth_provider_url = https://uaa.cf.example.com')
-        expect(rendered_template).to include('management.oauth_scopes = openid 5507278f-73bc-44fd-904d-03aea4add4f0.*')
-        expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
-        expect(rendered_template).to include('auth_oauth2.preferred_username_claims = user_name')
-        expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
-        expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')
-
-        expect(rendered_signing_key).to include('-----BEGIN PUBLIC KEY-----
-  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
-  6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
-  IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
-  B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
-  2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
-  QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
-  VwIDAQAB
-  -----END PUBLIC KEY-----')
-      end
+      expect(rendered_signing_key).to include('-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
+6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
+IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
+B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
+2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
+QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
+VwIDAQAB
+-----END PUBLIC KEY-----')
     end
   end
 

--- a/spec/unit/templates/13-oAuth_spec.rb
+++ b/spec/unit/templates/13-oAuth_spec.rb
@@ -36,6 +36,7 @@ VwIDAQAB
       expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
       expect(rendered_template).to include('management.oauth_enabled = true')
       expect(rendered_template).to include('management.oauth_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
+      expect(rendered_template).to include('management.oauth_client_secret = _')
       expect(rendered_template).to include('management.oauth_provider_url = https://uaa.cf.example.com')
       expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
       expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')

--- a/spec/unit/templates/13-oAuth_spec.rb
+++ b/spec/unit/templates/13-oAuth_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Configuration', template: true do
           'oauth' => {
             'enabled':true,
             'resource_server_id': '5507278f-73bc-44fd-904d-03aea4add4f0',
-            'uaa_client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
-            'uaa_location': 'https://uaa.cf.example.com',
+            'client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
+            'provider_url': 'https://uaa.cf.example.com',
             'signing_key_id': 'fake-key-id',
             'signing_key': "-----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
@@ -34,9 +34,9 @@ VwIDAQAB
     it 'renders the oAuth config in Cuttlefish format' do
       expect(rendered_template).to include('auth_backends.1 = rabbit_auth_backend_oauth2')
       expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
-      expect(rendered_template).to include('management.enable_uaa = true')
-      expect(rendered_template).to include('management.uaa_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
-      expect(rendered_template).to include('management.uaa_location = https://uaa.cf.example.com')
+      expect(rendered_template).to include('management.oauth_enabled = true')
+      expect(rendered_template).to include('management.oauth_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
+      expect(rendered_template).to include('management.oauth_provider_url = https://uaa.cf.example.com')
       expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
       expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
       expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')

--- a/spec/unit/templates/13-oAuth_spec.rb
+++ b/spec/unit/templates/13-oAuth_spec.rb
@@ -42,6 +42,7 @@ VwIDAQAB
       expect(rendered_template).to include('management.oauth_provider_url = https://uaa.cf.example.com')
       expect(rendered_template).to include('management.oauth_scopes = openid 5507278f-73bc-44fd-904d-03aea4add4f0.*')
       expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
+      expect(rendered_template).to include('auth_oauth2.preferred_username_claims = user_name')
       expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
       expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')
 

--- a/spec/unit/templates/13-oAuth_spec.rb
+++ b/spec/unit/templates/13-oAuth_spec.rb
@@ -10,51 +10,102 @@ RSpec.describe 'Configuration', template: true do
   }
 
   context 'when oauth is enabled' do
-		let(:manifest_properties) { {
-				'rabbitmq-server' => {
-          'oauth' => {
-            'enabled':true,
-            'resource_server_id': '5507278f-73bc-44fd-904d-03aea4add4f0',
-            'client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
-            'client_secret': 'secret',
-            'provider_url': 'https://uaa.cf.example.com',
-            'oauth_scopes': 'scopes',
-            'signing_key_id': 'fake-key-id',
-            'signing_key': "-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
-6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
-IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
-B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
-2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
-QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
-VwIDAQAB
------END PUBLIC KEY-----"
+    context 'when rabbitmq_server.version is 3.10' do
+      let(:manifest_properties) { {
+          'rabbitmq-server' => {
+            'version' => '3.10',
+            'oauth' => {
+              'enabled':true,
+              'resource_server_id': '5507278f-73bc-44fd-904d-03aea4add4f0',
+              'uaa_client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
+              'uaa_location': 'https://uaa.cf.example.com',
+              'signing_key_id': 'fake-key-id',
+              'signing_key': "-----BEGIN PUBLIC KEY-----
+  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
+  6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
+  IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
+  B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
+  2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
+  QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
+  VwIDAQAB
+  -----END PUBLIC KEY-----",
+            }
           }
-		    }
-      } 
-    }
-    it 'renders the oAuth config in Cuttlefish format' do
-      expect(rendered_template).to include('auth_backends.1 = rabbit_auth_backend_oauth2')
-      expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
-      expect(rendered_template).to include('management.oauth_enabled = true')
-      expect(rendered_template).to include('management.oauth_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
-      expect(rendered_template).to include('management.oauth_client_secret = secret')
-      expect(rendered_template).to include('management.oauth_provider_url = https://uaa.cf.example.com')
-      expect(rendered_template).to include('management.oauth_scopes = openid 5507278f-73bc-44fd-904d-03aea4add4f0.*')
-      expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
-      expect(rendered_template).to include('auth_oauth2.preferred_username_claims = user_name')
-      expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
-      expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')
+        }
+      }
 
-      expect(rendered_signing_key).to include('-----BEGIN PUBLIC KEY-----
-MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
-6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
-IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
-B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
-2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
-QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
-VwIDAQAB
------END PUBLIC KEY-----')
+      it 'renders the oAuth config in Cuttlefish format' do
+        expect(rendered_template).to include('auth_backends.1 = rabbit_auth_backend_oauth2')
+        expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
+        expect(rendered_template).to include('management.enable_uaa = true')
+        expect(rendered_template).to include('management.uaa_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
+        expect(rendered_template).to include('management.uaa_location = https://uaa.cf.example.com')
+        expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
+        expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
+        expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')
+
+        expect(rendered_signing_key).to include('-----BEGIN PUBLIC KEY-----
+  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
+  6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
+  IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
+  B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
+  2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
+  QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
+  VwIDAQAB
+  -----END PUBLIC KEY-----')
+      end
+    end
+
+    context 'when rabbitmq_server.version is 3.11 or greater' do
+
+      let(:manifest_properties) { {
+          'rabbitmq-server' => {
+            'version' => '3.11',
+            'oauth' => {
+              'enabled': true,
+              'resource_server_id': '5507278f-73bc-44fd-904d-03aea4add4f0',
+              'client_id': '67866802-73bc-44fd-904d-03aea4add4f0',
+              'client_secret': 'secret',
+              'provider_url': 'https://uaa.cf.example.com',
+              'oauth_scopes': 'scopes',
+              'signing_key_id': 'fake-key-id',
+              'signing_key': "-----BEGIN PUBLIC KEY-----
+  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
+  6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
+  IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
+  B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
+  2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
+  QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
+  VwIDAQAB
+  -----END PUBLIC KEY-----",
+            }
+          }
+        }
+      }
+
+      it 'renders the oAuth config in Cuttlefish format' do
+        expect(rendered_template).to include('auth_backends.1 = rabbit_auth_backend_oauth2')
+        expect(rendered_template).to include('auth_backends.2 = rabbit_auth_backend_internal')
+        expect(rendered_template).to include('management.oauth_enabled = true')
+        expect(rendered_template).to include('management.oauth_client_id = 67866802-73bc-44fd-904d-03aea4add4f0')
+        expect(rendered_template).to include('management.oauth_client_secret = secret')
+        expect(rendered_template).to include('management.oauth_provider_url = https://uaa.cf.example.com')
+        expect(rendered_template).to include('management.oauth_scopes = openid 5507278f-73bc-44fd-904d-03aea4add4f0.*')
+        expect(rendered_template).to include('auth_oauth2.resource_server_id = 5507278f-73bc-44fd-904d-03aea4add4f0')
+        expect(rendered_template).to include('auth_oauth2.preferred_username_claims = user_name')
+        expect(rendered_template).to include('auth_oauth2.default_key = fake-key-id')
+        expect(rendered_template).to include('auth_oauth2.signing_keys.fake-key-id = /var/vcap/jobs/rabbitmq-server/etc/oAuth-signing-key.pem')
+
+        expect(rendered_signing_key).to include('-----BEGIN PUBLIC KEY-----
+  MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2dP+vRn+Kj+S/oGd49kq
+  6+CKNAduCC1raLfTH7B3qjmZYm45yDl+XmgK9CNmHXkho9qvmhdksdzDVsdeDlhK
+  IdcIWadhqDzdtn1hj/22iUwrhH0bd475hlKcsiZ+oy/sdgGgAzvmmTQmdMqEXqV2
+  B9q9KFBmo4Ahh/6+d4wM1rH9kxl0RvMAKLe+daoIHIjok8hCO4cKQQEw/ErBe4SF
+  2cr3wQwCfF1qVu4eAVNVfxfy/uEvG3Q7x005P3TcK+QcYgJxav3lictSi5dyWLgG
+  QAvkknWitpRK8KVLypEj5WKej6CF8nq30utn15FQg0JkHoqzwiCqqeen8GIPteI7
+  VwIDAQAB
+  -----END PUBLIC KEY-----')
+      end
     end
   end
 


### PR DESCRIPTION
Dont merge this until RabbitMQ 3.10 package contains the Auth Code backport

This Pr configures the MGMT plugin oauth properties to enable the auth code flow. 

This also implements a bug in UAA, where the client_secret is required when refreshing an access token, even for public clients (that are not created with a client secret). You can by pass this requirement by setting the client secret to any valid string, hence "-" is used. 

Let me know if some commits can be squashed. 