### PR TITLE
Set scrape_interval in prom_scraper_config.

### DIFF
--- a/jobs/rabbitmq-server/spec
+++ b/jobs/rabbitmq-server/spec
@@ -149,6 +149,10 @@ properties:
     description: "Optional metric labels (see loggregator-agent's prom_scraper job for details)"
     default: {}
 
+  rabbitmq-server.prom_scraper_scrape_interval:
+    description: "The scrape interval for scraping the metrics endpoint"
+    default: "30s"
+
   rabbitmq-server.prom_scraper_detailed_endpoint_query:
     description: "Query parameters to append to the prom_scraper target endpoint for `/metrics/detailed`, including the leading `?`. See https://github.com/rabbitmq/rabbitmq-server/blob/master/deps/rabbitmq_prometheus/README.md#selective-querying-of-per-object-metrics"
     default: ""

--- a/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_config.yml.erb
@@ -44,3 +44,5 @@ labels:
   <%= key %>: <%= value %>
   <% end %>
 <% end %>
+
+scrape_interval: <%= p('rabbitmq-server.prom_scraper_scrape_interval') %>

--- a/jobs/rabbitmq-server/templates/prom_scraper_detailed_config.yml.erb
+++ b/jobs/rabbitmq-server/templates/prom_scraper_detailed_config.yml.erb
@@ -43,3 +43,5 @@ labels:
   <%= key %>: <%= value %>
   <% end %>
 <% end %>
+
+scrape_interval: <%= p('rabbitmq-server.prom_scraper_scrape_interval') %>

--- a/spec/unit/templates/prom_scraper_config_spec.rb
+++ b/spec/unit/templates/prom_scraper_config_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe 'Configuration', template: true do
     context 'when using the aggregated metrics' do
       it 'sets scrape path accordingly' do
         expect(rendered_template).to include('path: /metrics')
+        expect(rendered_template).to include('scrape_interval: 30s')
       end
     end
 
@@ -114,10 +115,11 @@ RSpec.describe 'Configuration', template: true do
           template = job.template('config/prom_scraper_detailed_config.yml')
           rendered_template = template.render(manifest, spec: instance, consumes: [link])
           expect(rendered_template).to include('path: /metrics/detailed')
+          expect(rendered_template).to include('scrape_interval: 30s')
         end
       end
 
-      context 'when the custom scrape query is unset' do
+      context 'when the custom scrape query is set' do
         before(:each) do
           manifest['rabbitmq-server']['prom_scraper_detailed_endpoint_query'] = '?foo=bar&baz=vhost'
         end
@@ -126,6 +128,7 @@ RSpec.describe 'Configuration', template: true do
           template = job.template('config/prom_scraper_detailed_config.yml')
           rendered_template = template.render(manifest, spec: instance, consumes: [link])
           expect(rendered_template).to include('path: /metrics/detailed?foo=bar&baz=vhost')
+          expect(rendered_template).to include('scrape_interval: 30s')
         end
       end
     end


### PR DESCRIPTION
Previously we were relying on setting the prom_scraper scrape_interval in the job spec, rather than in the prom_scraper_config YAML.