### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,10 +15,10 @@ golang/go1.20.1.linux-amd64.tar.gz:
   object_id: 6a8df097-9774-49d6-4064-572e38740dd1
   sha: sha256:000a5b1fca4f75895f78befeb2eecf10bfff3c428597f3f1e69133b63b911b02
 # this comment prevents git conflicts
-haproxy/haproxy-2.6.9.tar.gz:
-  size: 4045208
-  object_id: d39b0f15-ea4e-4376-5dd2-3e6bf16485f6
-  sha: sha256:f01a1c5f465dc1b5cd175d0b28b98beb4dfe82b5b5b63ddcc68d1df433641701
+haproxy/haproxy-2.6.10.tar.gz:
+  size: 4056147
+  object_id: 6cea0c0e-0d26-46d1-415e-4536c2214c18
+  sha: sha256:e71b2cd9ca1043345f083a5225078ccf824dced2b5779d86f11fa4e88f451773
 # this comment prevents git conflicts
 openssl/openssl-1.1.1t.tar.gz:
   size: 9881866

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="2.6.9"
+VERSION="2.6.10"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 2.6.9
+  version: 2.6.10
 files:
-- haproxy/haproxy-2.6.9.tar.gz
+- haproxy/haproxy-2.6.10.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 2.6.10