### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,10 +15,10 @@ golang/go1.20.3.linux-amd64.tar.gz:
   object_id: 5fc6c6b8-a758-42d7-67ac-24b191d4dc12
   sha: sha256:979694c2c25c735755bf26f4f45e19e64e4811d661dd07b8c010f7a8e18adfca
 # this comment prevents git conflicts
-haproxy/haproxy-2.6.12.tar.gz:
-  size: 4060878
-  object_id: 8d0de861-5e08-4ed6-4baf-c0cc723f11cc
-  sha: sha256:58f9edb26bf3288f4b502658399281cc5d6478468bd178eafe579c8f41895854
+haproxy/haproxy-2.6.13.tar.gz:
+  size: 4065839
+  object_id: 759eebd7-e614-46ec-6af0-0a9ba76f50fc
+  sha: sha256:d69ff5233dbca657132ef280d111222ec1e33f5be1c1937d4e9ff516f63f5243
 # this comment prevents git conflicts
 openssl/openssl-1.1.1t.tar.gz:
   size: 9881866

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="2.6.12"
+VERSION="2.6.13"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 2.6.12
+  version: 2.6.13
 files:
-- haproxy/haproxy-2.6.12.tar.gz
+- haproxy/haproxy-2.6.13.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 2.6.13