### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,10 +15,10 @@ golang/go1.20.5.linux-amd64.tar.gz:
   object_id: 96822958-9b7e-43a9-6f20-de2321ea39a9
   sha: sha256:d7ec48cde0d3d2be2c69203bc3e0a44de8660b9c09a6e85c4732a3f7dc442612
 # this comment prevents git conflicts
-haproxy/haproxy-2.6.13.tar.gz:
-  size: 4065839
-  object_id: 759eebd7-e614-46ec-6af0-0a9ba76f50fc
-  sha: sha256:d69ff5233dbca657132ef280d111222ec1e33f5be1c1937d4e9ff516f63f5243
+haproxy/haproxy-2.6.14.tar.gz:
+  size: 4067797
+  object_id: a9e4f170-c45e-40ab-472f-0a3db0b83407
+  sha: sha256:bd3dd9fa60391ca09e1225e1ac3163e45be83c3f54f2fd76a30af289cc6e4fd4
 # this comment prevents git conflicts
 openssl/openssl-1.1.1u.tar.gz:
   size: 9892176

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="2.6.13"
+VERSION="2.6.14"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 2.6.13
+  version: 2.6.14
 files:
-- haproxy/haproxy-2.6.13.tar.gz
+- haproxy/haproxy-2.6.14.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 2.6.14