### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,10 +15,10 @@ golang/go1.21.0.linux-amd64.tar.gz:
   object_id: e2788bc5-a3b5-4337-5c57-c419703add06
   sha: sha256:d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742
 # this comment prevents git conflicts
-haproxy/haproxy-2.6.14.tar.gz:
-  size: 4067797
-  object_id: a9e4f170-c45e-40ab-472f-0a3db0b83407
-  sha: sha256:bd3dd9fa60391ca09e1225e1ac3163e45be83c3f54f2fd76a30af289cc6e4fd4
+haproxy/haproxy-2.6.15.tar.gz:
+  size: 4074156
+  object_id: 94beb1ef-ee7a-4a93-7124-a9c0d4a23b8d
+  sha: sha256:41f8e1695e92fafdffe39690a68993f1a0f5f7f06931a99e9a153f749ea39cfd
 # this comment prevents git conflicts
 openssl/openssl-1.1.1v.tar.gz:
   size: 9893443

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="2.6.14"
+VERSION="2.6.15"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 2.6.14
+  version: 2.6.15
 files:
-- haproxy/haproxy-2.6.14.tar.gz
+- haproxy/haproxy-2.6.15.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 2.6.15