### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -20,10 +20,10 @@ golang/go1.22.2.linux-amd64.tar.gz:
   object_id: 7757fbde-6293-4d44-616f-124db7723f69
   sha: sha256:5901c52b7a78002aeff14a21f93e0f064f74ce1360fce51c6ee68cd471216a17
 # this comment prevents git conflicts
-haproxy/haproxy-2.6.16.tar.gz:
-  size: 4084854
-  object_id: f78310f9-c327-4682-7051-e76e94208dae
-  sha: sha256:faac6f9564caf6e106fe22c77a1fb35406afc8cd484c35c2c844aaf0d7a097fb
+haproxy/haproxy-2.6.17.tar.gz:
+  size: 4094829
+  object_id: '085503b4-8bf5-4063-545d-322063427507'
+  sha: sha256:be48ee8ff9127c402b4c6cf1445cef7052f2c540ed1eff2dd04af677b8cd9dd0
 # this comment prevents git conflicts
 rabbitmq-server-3.11/rabbitmq-server-generic-unix-3.11.28.tar.xz:
   size: 15594916

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="2.6.16"
+VERSION="2.6.17"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 2.6.16
+  version: 2.6.17
 files:
-- haproxy/haproxy-2.6.16.tar.gz
+- haproxy/haproxy-2.6.17.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 2.6.17