### PR TITLE
RMQFPAS-107 changes for inter-node TLS

### DIFF
--- a/jobs/rabbitmq-server/templates/config-files/inter_node_tls.config.erb
+++ b/jobs/rabbitmq-server/templates/config-files/inter_node_tls.config.erb
@@ -16,18 +16,14 @@
     {keyfile,    "/var/vcap/jobs/rabbitmq-server/etc/key.pem"},
     {fail_if_no_peer_cert, true},
     {verify, verify_peer},
-    {versions, ['tlsv1.3']},
-    {customize_hostname_check, [
-      {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
-    ]}
+    {versions, ['tlsv1.3','tlsv1.2']}
   ]},
   {client, [
     {cacertfile, "/var/vcap/jobs/rabbitmq-server/etc/cacert.pem"},
     {certfile,   "/var/vcap/jobs/rabbitmq-server/etc/cert.pem"},
     {keyfile,    "/var/vcap/jobs/rabbitmq-server/etc/key.pem"},
-    {fail_if_no_peer_cert, true},
     {verify, verify_peer},
-    {versions, ['tlsv1.3']},
+    {versions, ['tlsv1.3','tlsv1.2']},
     {customize_hostname_check, [
       {match_fun, public_key:pkix_verify_hostname_match_fun(https)}
     ]}

--- a/jobs/rabbitmq-server/templates/config.erb
+++ b/jobs/rabbitmq-server/templates/config.erb
@@ -5,5 +5,6 @@ RMQ_FD_LIMIT="${RMQ_FD_LIMIT:?must be set}"
 SKIP_PREPARE_FOR_UPGRADE=true
 <% end %>
 <% if p('rabbitmq-server.ssl.inter_node_enabled') -%>
-RABBITMQ_CTL_ERL_ARGS="-proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"
+ERL_SSL_PATH="$(erl -noinput -eval 'io:format("~s~n", [filename:dirname(code:which(inet_tls_dist))])' -s init stop)"
+RABBITMQ_CTL_ERL_ARGS="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"
 <% end %>

--- a/spec/bash/setup_test.bash
+++ b/spec/bash/setup_test.bash
@@ -39,8 +39,8 @@ T_create_env_config_file() {
     expect_to_contain "$(<$dir/env)" "RABBITMQ_PLUGINS_EXPAND_DIR=/var/vcap/store/rabbitmq/mnesia/db-plugins-expand"
     expect_to_contain "$(<$dir/env)" "ENABLED_PLUGINS_FILE=$plugins_file"
     expect_to_contain "$(<$dir/env)" "USE_LONGNAME=false"
-    expect_to_contain "$(<$dir/env)" "SERVER_ADDITIONAL_ERL_ARGS=\"-proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"
-    expect_to_contain "$(<$dir/env)" "CTL_ERL_ARGS=\"-proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"
+    expect_to_contain "$(<$dir/env)" "SERVER_ADDITIONAL_ERL_ARGS=\"-pa \$ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"
+    expect_to_contain "$(<$dir/env)" "CTL_ERL_ARGS=\"-pa \$ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"
 
     ) || ( $T_fail "Failed to create conf_env file" && return 1 )
 }

--- a/spec/unit/templates/config_spec.rb
+++ b/spec/unit/templates/config_spec.rb
@@ -27,12 +27,13 @@ RSpec.describe 'Configuration', template: true do
         }
       }
     end
+
     context 'TLS is disabled' do
       before do
         manifest_properties['rabbitmq-server']['ssl']['enabled'] = false
       end
       it 'does contain erl args for rabbitmqctl' do
-        expect(rendered_template).to include('RABBITMQ_CTL_ERL_ARGS="-proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"')
+        expect(rendered_template).to include('RABBITMQ_CTL_ERL_ARGS="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"')
       end
     end
 
@@ -41,7 +42,7 @@ RSpec.describe 'Configuration', template: true do
         manifest_properties['rabbitmq-server']['ssl']['enabled'] = true
       end
       it 'does contain erl args for rabbitmqctl' do
-        expect(rendered_template).to include('RABBITMQ_CTL_ERL_ARGS="-proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"')
+        expect(rendered_template).to include('RABBITMQ_CTL_ERL_ARGS="-pa $ERL_SSL_PATH -proto_dist inet_tls -ssl_dist_optfile /var/vcap/jobs/rabbitmq-server/etc/inter_node_tls.config"')
       end
     end
   end


### PR DESCRIPTION
* Ensure `-pa ERL_SSL_PATH` is passed to Erlang vm
* Use `CTL_ERL_ARGS`