### PR TITLE
Update erlang-26 package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -10,10 +10,10 @@ erlang-25/otp_src_oss_25.3.2.13.tgz:
   object_id: eb08689f-e005-4f79-4f12-df23a136c5b5
   sha: sha256:ee69fe70fccd277f28f628c1c368bf65325f4900c5dd39185e426218bcb1c1d5
 # this comment prevents git conflicts
-erlang-26/otp_src_oss_26.2.5.2.tgz:
-  size: 63017713
-  object_id: 9934d156-bb7d-4060-7746-8c0f24d0f052
-  sha: sha256:96d80cff18ed0d63e5f787ffd70498244d7a16988f0797bec323246ca670d3f6
+erlang-26/otp_src_oss_26.2.5.3.tgz:
+  size: 63002001
+  object_id: f796d8b7-197d-4ba9-6fb0-73cc27b25f14
+  sha: sha256:e907f55f379be3392bb350e7d6eedbe803dc1c0fb6a8b7fa5b710e0f929764d8
 # this comment prevents git conflicts
 golang/go1.23.0.linux-amd64.tar.gz:
   size: 73590011

--- a/packages/erlang-26/packaging
+++ b/packages/erlang-26/packaging
@@ -4,7 +4,7 @@ export HOME=${BOSH_INSTALL_DIR}
 
 cpus="$(grep -c ^processor /proc/cpuinfo)"
 
-VERSION="26.2.5.2"
+VERSION="26.2.5.3"
 MAJOR_VERSION="26"
 echo "$MAJOR_VERSION" > "$BOSH_INSTALL_TARGET/erlang_version"
 

--- a/packages/erlang-26/spec
+++ b/packages/erlang-26/spec
@@ -1,6 +1,6 @@
 ---
 name: erlang-26
 metadata:
-  version: 26.2.5.2
+  version: 26.2.5.3
 files:
-- erlang-26/otp_src_oss_26.2.5.2.tgz
+- erlang-26/otp_src_oss_26.2.5.3.tgz


### PR DESCRIPTION
This PR updates the version of erlang-26 to 26.2.5.3