### PR TITLE
Update haproxy package

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -20,10 +20,10 @@ golang/go1.23.0.linux-amd64.tar.gz:
   object_id: 84d574d6-d4a7-4097-790d-263dcb73c205
   sha: sha256:905a297f19ead44780548933e0ff1a1b86e8327bb459e92f9c0012569f76f5e3
 # this comment prevents git conflicts
-haproxy/haproxy-2.6.18.tar.gz:
-  size: 4103766
-  object_id: bef8a52d-c998-42f7-52f1-448b61c7dc8c
-  sha: sha256:1b36d3c618360eff7cdc2b70dd53affdf9c939d0fdf8602ac2d77018535f709a
+haproxy/haproxy-2.6.19.tar.gz:
+  size: 4110701
+  object_id: '044911bb-ac89-4288-501a-9bc9387e1738'
+  sha: sha256:890a2fdd12e92115556b5d2ff578c1f9a8e48147ea5fe9efb8145685f723a0e9
 # this comment prevents git conflicts
 rabbitmq-server-3.11/rabbitmq-server-generic-unix-3.11.28.tar.xz:
   size: 15594916

--- a/packages/haproxy/packaging
+++ b/packages/haproxy/packaging
@@ -1,6 +1,6 @@
 set -e
 
-VERSION="2.6.18"
+VERSION="2.6.19"
 
 tar xzf haproxy/haproxy-${VERSION}.tar.gz
 cd haproxy-${VERSION}

--- a/packages/haproxy/spec
+++ b/packages/haproxy/spec
@@ -1,7 +1,7 @@
 ---
 name: haproxy
 metadata:
-  version: 2.6.18
+  version: 2.6.19
 files:
-- haproxy/haproxy-2.6.18.tar.gz
+- haproxy/haproxy-2.6.19.tar.gz
 dependencies: []


### PR DESCRIPTION
This PR updates the version of haproxy to 2.6.19